### PR TITLE
Kolmannen piirin loitsukuvaukset

### DIFF
--- a/Loitsut/2_piirin_loitsut.md
+++ b/Loitsut/2_piirin_loitsut.md
@@ -62,3 +62,5 @@ A-V Aaveratsusta voimapalautukseen.
 Ylätaso [Loitsut](Loitsut.md)
 
 Edellinen [Ensimmäisen piirin loitsut](1_piirin_loitsut.md)
+
+Seuraava [Kolmannen piirin loitsut](3_piirin_loitsut.md)

--- a/Loitsut/3_piirin_loitsut.md
+++ b/Loitsut/3_piirin_loitsut.md
@@ -1,0 +1,53 @@
+## Kolmannen piirin loitsut
+
+A-V ajatustenvaihdosta vilahdukseen.
+
+ - [Ajatustenvaihto](Ajatustenvaihto.md)
+ - [Elvytys](Elvytys.md)
+ - [Eläinten kutsuminen](Eläinten_kutsuminen.md)
+ - [Epäkuollut palvelija](Epäkuollut_palvelija.md)
+ - [Hidastus](Hidastus.md)
+ - [Huomaamattomuus](Huomaamattomuus.md)
+ - [Hypnoottinen kuvio](Hypnoottinen_kuvio.md)
+ - [Kaasumuoto](Kaasumuoto.md)
+ - [Kasveille puhuminen](Kasveille_puhuminen.md)
+ - [Kasvikasvu](Kasvikasvu.md)
+ - [Kielillä puhuminen](Kielillä_puhuminen.md)
+ - [Kiiruhtaminen](Kiiruhtaminen.md)
+ - [Kirouksen kumoaminen](Kirouksen_kumoaminen.md)
+ - [Kirous](Kirous.md)
+ - [Kiveen sulautuminen](Kiveen_sulautuminen.md)
+ - [Kuolleille puhuminen](Kuolleille_puhuminen.md)
+ - [Kuvajainen](Kuvajainen.md)
+ - [Lento](Lento.md)
+ - [Löyhkäävä pilvi](Löyhkäävä_pilvi.md)
+ - [Maja](Maja.md)
+ - [Myrskyvalli](Myrskyvalli.md)
+ - [Parannuksen mahtisana](Parannuksen_mahtisana.md)
+ - [Pelko](Pelko.md)
+ - [Päivänvalo](Päivänvalo.md)
+ - [Räntäsade](Räntäsade.md)
+ - [Salama](Salama.md)
+ - [Selvännäkeminen](Selvännäkeminen.md)
+ - [Suoja energialta](Suoja_energialta.md)
+ - [Suojelushenget](Suojelushenget.md)
+ - [Taikakehä](Taikakehä.md)
+ - [Taikaratsu](Taikaratsu.md)
+ - [Taikuuden purkaminen](Taikuuden_purkaminen.md)
+ - [Toivon majakka](Toivon_majakka.md)
+ - [Torjuva merkki](Torjuva_merkki.md)
+ - [Tulipallo](Tulipallo.md)
+ - [Ukkosen kutsuminen](Ukkosen_kutsuminen.md)
+ - [Vampyyrikosketus](Vampyyrikosketus.md)
+ - [Vastaloitsu](Vastaloitsu.md)
+ - [Veden hengittäminen](Veden_hengittäminen.md)
+ - [Veden ja ruoan luominen](Veden_ja_ruoan_luominen.md)
+ - [Vetten päällä kävely](Vetten_päällä_kävely.md)
+ - [Vilahdus](Vilahdus.md)
+
+ 
+----
+
+Ylätaso [Loitsut](Loitsut.md)
+
+Edellinen [Toisen piirin loitsut](2_piirin_loitsut.md)

--- a/Loitsut/Ajatustenvaihto.md
+++ b/Loitsut/Ajatustenvaihto.md
@@ -1,0 +1,21 @@
+### Ajatustenvaihto
+
+*3-piirin luominen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** rajaton
+
+**Komponentit:** taikasana, ele, aines (lyhyt pala kuparilankaa)
+
+**Kesto:** 1 kierros
+
+Voit lähettää alle 25 sanaa pitkän viestin olennolle, jonka tunnet. Kohde kuulee viestin päässään ja tunnistaa sinut viestin lähettäjäksi, jos tuntee sinut, ja voi vastata sinulle alle 25 sanalla. Loitsun avulla kaikki olennot, joiden älykkyys on 1 tai enemmän, ymmärtävät sinun viestisi.
+
+Voit lähettää loitsun niin kauas kuin haluat ja jopa toisille maailmatasoille, mutta on olemassa viiden prosentin mahdollisuus, että loitsu ei pääse perille, kun sen lähettää toiselle maailmatasolle.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Seuraava [Elvytys](Elvytys.md)

--- a/Loitsut/Elvytys.md
+++ b/Loitsut/Elvytys.md
@@ -1,0 +1,21 @@
+### Elvytys
+
+*3-piirin kuolontaikuus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele, aines (timantteja 300 kr arvosta, jotka tuhoutuvat loitsussa)
+
+**Kesto:** välitön
+
+Kosketat olentoa, joka on kuollut viimeisen minuutin aikana. Tuo olento palaa henkiin ja sillä on 1 osumapiste. Tämä loitsu ei voi herättää henkiin olentoa, joka on kuollut vanhuuteen, eikä sillä voi palauttaa puuttuvia ruumiinosia.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Ajatustenvaihto](Ajatustenvaihto.md)
+
+Seuraava [Eläinten kutsuminen](Eläinten_kutsuminen.md)

--- a/Loitsut/Eläinten_kutsuminen.md
+++ b/Loitsut/Eläinten_kutsuminen.md
@@ -1,0 +1,33 @@
+### Eläinten kutsuminen
+
+*3-piirin kutsuminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 24 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** keskittyminen, korkeintaan 1 tunnin
+
+Kutsut esiin eläinhahmon ottavia keijujen henkiä. Ne ilmestyvät haluamaasi vapaaseen tilaan loitsun kantamalla Valitse yksi seuraavista vaihtoehdoista kutsuttujen eläinten suhteen: 
+ - Yksi eläin, joka on haastearvoltaan 2 tai pienempi 
+ - Kaksi eläintä, jotka ovat haastearvoltaan 1 tai pienempi 
+ - Neljä eläintä, jotka ovat haastearvoltaan 1/2 tai pienempi
+ - Kahdeksan eläintä, jotka ovat haastearvoltaan 1/4 tai  pienempi 
+
+Jokainen eläin lasketaan myös keijuksi. Eläinhahmo katoaa, kun sen osumapisteet laskevat nollaan, tai kun loitsun vaikutus lakkaa.
+
+Kutsutut eläinhahmot ovat ystävällisiä sinulle ja tovereillesi. Heitä aloiteheitto koko eläinjoukolle. Ne tottelevat sanallisia ohjeitasi (ei tarvitse toimintoa sinulta). Jos et anna niille ohjeita, ne puolustavat itseään, mutta eivät toimi muuten.
+
+Pelinjohtaja pitää kirjaa eläinten tiedoista.
+
+**Korkeammilla loitsuvarauksilla.** Jos loitsit tämän loitsun käyttäen korkeamman piirin loitsuvarauksen, voit valita yhden ylläolevista vaihtoehdoista ja saat kutsuttua enemmän eläimiä: kaksi kertaa enemmän käyttäen viidennen piirin loitsuvarauksen, kolme kertaa enemmän käyttäen seitsemännen piirin loitsuvarauksen ja neljä kertaa enemmän käyttäen yhdeksännen piirin loitsuvarauksen.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Elvytys](Elvytys.md)
+
+Seuraava [Epäkuollut palvelija](Epäkuollut_palvelija.md)

--- a/Loitsut/Epäkuollut_palvelija.md
+++ b/Loitsut/Epäkuollut_palvelija.md
@@ -1,0 +1,27 @@
+### Epäkuollut palvelija
+
+*3-piirin kuolontaikuus* 
+
+**Loitsimisviive:** 1 minuutti
+
+**Kantama:** 4 metriä
+
+**Komponentit:** taikasana, ele, aines (verenpisara, pala lihaa ja ripaus luujauhoa)
+
+**Kesto:** välitön
+
+Tämä loitsu luo epäkuolleen palvelijan. Valitse loitsun kantamalla oleva pienen tai keskikokoisen olennon luukasa tai ruumis. Loitsu herättää ruumiin tai luukasan epäkuolleeksi olennoksi, jolloin kohteesta tulee joko luuranko tai zombi.
+
+Voit jokaisella vuorollasi komentaa luomiasi olentoja, jotka ovat 24 metrin säteellä sinusta. Teet sen ajattelemalla ja käyttäen bonustoiminnon siihen. Kun komennossasi on useampia olentoja, voit päättää annatko saman komennon yhdelle vai useammalle niistä. Saat päättää, minkä toiminnon olento tekee ja minne se liikkuu seuraavalla vuorolla, tai sitten voit antaa sille yleisluontoisen ohjeen, kuten että sen tulisi vartioida jotain huonetta tai käytävää. Jos et anna sille mitään käskyä, se vain puolustautuu, kun sitä vastaan hyökätään. Käskyn antamisen jälkeen olento noudattaa käskyä, kunnes on saanut suoritettua sen. 
+
+Luomasi olento on komennossasi 24 tuntia, jonka jälkeen se ei tottele sinua. Pitääksesi yllä komentoa sinun tulee loitsia tämä loitsu uudestaan samaan olentoon ennen kuin 24 tuntia on kulunut. Tällä tavalla loitsien voit uusia komennon jopa neljään epäkuolleeseen sen sijaan, että loisit uusia.
+
+**Korkeammilla loitsuvarauksilla.** Jos loitsit tämän loitsun käyttäen neljännen tai sitä korkeamman piirin loitsuvarauksen, saat luotua tai pidettyä yllä komentoa kahdelle epäkuolleelle lisää jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla. Jokaisen luoduista olennoista täytyy syntyä eri ruumiista tai luukasasta.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Eläinten kutsuminen](Eläinten_kutsuminen.md)
+
+Seuraava [Hidastus](Hidastus.md)

--- a/Loitsut/Hidastus.md
+++ b/Loitsut/Hidastus.md
@@ -1,0 +1,25 @@
+### Hidastus
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 48 metriä
+
+**Komponentit:** taikasana, ele, aines (pisara siirappia)
+
+**Kesto:** keskittyminen, korkeintaan 1 minuutin
+
+Tällä loitsulla voit hidastaa ajan kulkua korkeintaan kuudelta olennolta kantamalla, jotka mahtuvat 16x16x16 metrin kokoisen kuution sisään. Jokaisen loitsun kohteena olevan olennon pitää heittää viisaus-pelastusheitto. Jos olento epäonnistuu pelastusheitossa, on se loitsun vaikutuksen alaisena loitsun keston ajan. Olennon kulkunopeus puolittuu, sen puolustukseen ja ketteryys-pelastusheittoihin tulee -2 muutos, ja se ei voi tehdä reaktiotoimintoja. Omalla vuorollaan kohde voi tehdä joko normaalin toiminnon tai bonustoiminnon, mutta ei molempia. Kohde ei myöskään voi hyökätä kuin kerran, vaikka normaalisti voisikin hyökätä useammin.
+
+Jos loitsun vaikutuksen alaisena oleva olento yrittää loitsia, saat heittää n20. Jos heiton tulos on 11 tai suurempi, loitsu tapahtuu vasta kyseisen olennon seuraavalla vuorolla ja olennon täytyy käyttää toiminto saadakseen loitsu valmiiksi. Jos kohde ei toimi niin, loitsu menee hukkaan.
+
+***Hidastuksen*** vaikutuksen alaisena olevat olennot heittävät viisaus-pelastusheiton jokaisen vuoronsa lopuksi. Onnistuneessa pelastusheitossaan loitsun vaikutus lakkaa.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Epäkuollut palvelija](Epäkuollut_palvelija.md)
+
+Seuraava [Huomaamattomuus](Huomaamattomuus.md)

--- a/Loitsut/Huomaamattomuus.md
+++ b/Loitsut/Huomaamattomuus.md
@@ -1,0 +1,21 @@
+### Huomaamattomuus
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele, aines (vähintään 25 kr arvoinen hyppysellinen timanttipölyä, joka katoaa sen jälkeen kun se on siroteltu kohteen ylle)
+
+**Kesto:** 8 tuntia
+
+Kätket loitsun kohteen loitsun keston ajaksi kaikelta ennustamisen koulukunnan taikuudelta. Kohde voi olla esine, paikka tai vapaaehtoinen olento, kunhan se ei ole kolmea metriä isompi mihinkään suuntaan. Kohdetta ei voida havaita ennustamisen koulukunnan taikuudella eikä etäkatselemisella.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Hidastus](Hidastus.md)
+
+Seuraava [Hypnoottinen kuvio](Hypnoottinen_kuvio.md)

--- a/Loitsut/Hypnoottinen_kuvio.md
+++ b/Loitsut/Hypnoottinen_kuvio.md
@@ -1,0 +1,23 @@
+### Hypnoottinen kuvio
+
+*3-piirin illuusio* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 48 metriä
+
+**Komponentit:** ele, aines (hohtava keppi tai kristalliastia, jossa fosforia)
+
+**Kesto:** keskittyminen, korkeintaan 1 minuutin
+
+Luot ilmaan loitsun kantamalle pyörteilevän värikuvion, joka näkyy paikallaan hetken. Kaikkien läsnä olevien olentojen, jotka näkevät kuvion, tulee heittää viisaus-pelastusheitto. Jos olento epäonnistuu pelastusheitossa, se on *lumottu*. *Lumottu* olento on *toimintakyvytön* ja hänen kulkunopeutensa on 0. 
+
+Loitsun vaikutus lakkaa, jos sen kohde kärsii vahinkoa tai jos joku muu ravistelee häntä käyttäen toimintonsa siihen. 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Huomaamattomuus](Huomaamattomuus.md)
+
+Seuraava [Kaasumuoto](Kaasumuoto.md)

--- a/Loitsut/Kaasumuoto.md
+++ b/Loitsut/Kaasumuoto.md
@@ -1,0 +1,25 @@
+### Druidintaito
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele, aines (pala harsoa ja hieman savua)
+
+**Kesto:** keskittyminen, korkeintaan 1 tunnin
+
+Muutat vapaaehtoisen olennon ja kaikki tämän kantamat tavarat sumupilveksi. 
+
+Ollessaan tässä muodossa kohde voi liikkua ainoastaan lentämällä 4 metriä vuorossa. Hän voi myös liikkua toisten olentojen läpi sekä liikkua samaan tilaan heidän kanssaan. Kohteella on sietokyky normaalia vahinkoa vastaan ja *etu* voimakkuuteen, ketteryyteen ja sitkeyteen liittyviin pelastusheittoihin. Kohde voi kulkea pienten reikien ja rakojen läpi, mutta nesteistä hän ei pääse läpi. Kohde ei voi pudota, ja *taintuneena* sekä *toimintakyvyttömänä* hän jää leijailemaan ilmaan.
+
+Kaasumuodossa oleva kohde ei voi puhua, käyttää esineitä eikä myöskään pudottaa omia kantamuksiaan. Kohde ei voi myöskään hyökätä tai loitsia. Loitsu lakkaa ennenaikaisesti, jos kohteen osumapisteet laskevat nollaan.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Hypnoottinen kuvio](Hypnoottinen_kuvio.md)
+
+Seuraava [Kasveille puhuminen](Kasveille_puhuminen.md)

--- a/Loitsut/Kasveille_puhuminen.md
+++ b/Loitsut/Kasveille_puhuminen.md
@@ -1,0 +1,29 @@
+### Kasveille puhuminen
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** itse (12 metrin säde)
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** 10 minuuttia
+
+Saat kasvit 12 metrin säteellä itsestäsi tietoisiksi sinusta. Ne voivat kommunikoida kanssasi ja noudattaa yksinkertaisia ohjeita. Voit kysellä kasveilta viimeisen päivän tapahtumista ja saat tietoa ohi kulkeneista olennoista, säästä ja muista ilmiöistä.
+
+Voit myös muuttaa vaikean, kasveista koostuvan maaston, kuten piikkipensaikon normaaliksi maastoksi tai voit muuttaa normaalin kasveja kasvavan maaston vaikeakulkuiseksi maastoksi, jolloin oksat ja kasvien varret estelevät kulkijoita.
+
+Loitsun avulla ei saa kasveja irrottamaan juuriaan maasta, mutta ne voivat vapaasti liikutella oksia, varsia ja muita maanpäällisiä osiaan. 
+
+Jos loitsun vaikutusalueella on kasviolento, voit kommunikoida sen kanssa kuin teillä olisi yhteinen kieli, mutta et voi komentaa sitä. 
+
+Tällä loitsulla saa myös ***kampitus***-loitsulla luodut kasvit päästämään irti kohteestaan.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kaasumuoto](Kaasumuoto.md)
+
+Seuraava [Kasvikasvu](Kasvikasvu.md)

--- a/Loitsut/Kasvikasvu.md
+++ b/Loitsut/Kasvikasvu.md
@@ -1,0 +1,25 @@
+### Kasvikasvu
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto tai 8 tuntia
+
+**Kantama:** 60 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** välitön
+
+Tämä loitsu antaa kasveille elinvoimaa kahdella mahdollisella eri käyttötavalla, joilla saat joko lyhyt- tai pitkäaikaisen hyödyn loitsusta. 
+
+Jos loitsit tämän loitsun käyttäen 1 toiminnon, voit valita jonkin pisteen kantamalla. Kaikki normaalit kasvit ylikasvavat 40 metrin säteellä tuosta pisteestä. Alueesta tulee niin tiheä, että neljän metrin kulkeminen vaatii 8 metrin verran liikettä. Voit jättää haluamiasi alueita avoimiksi loitsun vaikutusalueelta (esimerkiksi polun alueen läpi).
+
+Jos loitsit tämän loitsun 8 tunnin loitsimisajalla, teet alueesta hedelmällisimmän. Kaikki kasvit kilometrin säteellä sinusta tuottavat kaksinkertaisen sadon seuraavan vuoden aikana.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kasveille puhuminen](Kasveille_puhuminen.md)
+
+Seuraava [Kielillä puhuminen](Kielillä_puhuminen.md)

--- a/Loitsut/Kielillä_puhuminen.md
+++ b/Loitsut/Kielillä_puhuminen.md
@@ -1,0 +1,21 @@
+### Kielillä puhuminen
+
+*3-piirin ennustaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele, aines (pieni tornin muotoinen savipatsas)
+
+**Kesto:** 1 tunti
+
+Tämä loitsu antaa koskettamallesi olennolle kyvyn ymmärtää mitä tahansa puhuttua kieltä ja muille kyvyn ymmärtää hänen puhettaan.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kasvikasvu](Kasvikasvu.md)
+
+Seuraava [Kiiruhtaminen](Kiiruhtaminen.md)

--- a/Loitsut/Kiiruhtaminen.md
+++ b/Loitsut/Kiiruhtaminen.md
@@ -1,0 +1,21 @@
+### Kiiruhtaminen
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 12 metriä
+
+**Komponentit:** taikasana, ele, aines (viipale lakritsakasvin juurta)
+
+**Kesto:** keskittyminen, enintään 1 minuutti
+
+Voit valita loitsun kohteeksi vapaaehtoisen olennon loitsun kantamalla, johon sinulla on näköyhteys. Loitsun keston ajan kohteella on +2 bonus puolustukseen sekä *etu* ketteryys-pelastusheittoihin, ja hän saa yhden ylimääräisen toiminnon jokaisella vuorollaan. Ylimääräistä toimintoa voidaan käyttää vain hyökkäykseen (vain yksi aseellinen hyökkäys), ryntäykseen, irtautumiseen, esineen käyttämiseen tai piiloutumiseen. Loitsun lakattua vaikuttamasta kohde ei voi liikkua tai tehdä mitään toimintoja seuraavan vuoronsa aikana väsymyksen pyyhkiessä hänen ylitseen. Tämän jälkeen hän voi toimia normaaliin tapaan. 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kielillä puhuminen](Kielillä_puhuminen.md)
+
+Seuraava [Kirouksen kumoaminen](Kirouksen_kumoaminen.md)

--- a/Loitsut/Kirouksen_kumoaminen.md
+++ b/Loitsut/Kirouksen_kumoaminen.md
@@ -1,0 +1,21 @@
+### Kirouksen kumoaminen
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** välitön
+
+Kosketuksellasi voit kumota kaikki kohteeseen vaikuttavat kiroukset. Tämä loitsu ei poista kirotun esineen kirousta, mutta antaa sen käyttäjän päästää irti kirotusta esineestä tai riisua kirotun esineen. 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kiiruhtaminen](Kiiruhtaminen.md)
+
+Seuraava [Kirous](Kirous.md)

--- a/Loitsut/Kirous.md
+++ b/Loitsut/Kirous.md
@@ -1,0 +1,32 @@
+### Kirous
+
+*3-piirin kuolontaikuus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** keskittyminen, korkeintaan 1 minuutin
+
+Kosket olentoa, jonka pitää heittää viisaus-pelastusheitto tai tulla kirotuksi loitsun keston ajaksi. Loitsiessasi kirouksen valitse yksi alla olevista vaihtoehdoista: 
+ - Valitse jokin ominaisuuksista. Kirouksen aikana kohteella on *haitta* ominaisuusheittoihin ja pelastusheittoihin kyseiseen ominaisuuteen liittyen. 
+ - Kirouksen aikana kohteella on *haitta* hyökkäysheittoihin sinua vastaan. 
+ - Kirouksen aikana kohteen pitää heittää viisaus-pelastusheitto jokaisen vuoronsa aluksi. Kohteen epäonnistuessa pelastusheitossa, hän ei tee sillä vuorolla mitään. 
+ - Kirouksen aikana hyökkäyksesi ja loitsusi tekevät 1n8 
+kuolonvahinkoa lisävahinkona kohteelle. 
+
+***Kirouksen kumoaminen*** -loitsu purkaa tämän loitsun vaikutuksen.
+
+Voit myös sopia pelinjohtajan kanssa, voiko tällä loitsulla olla joku muu vaikutus kuin jokin yllä luetelluista.
+
+**Korkeammilla loitsuvarauksilla.** Jos loitsit tämän loitsun käyttäen neljännen piirin loitsuvarauksen, loitsun kesto kasvaa 10 minuuttiin. Jos loitsit tämän loitsun käyttäen viidennen piirin loitsuvarauksen, loitsun kesto kasvaa 8 tuntiin. Jos loitsit tämän loitsun käyttäen seitsemännen piirin loitsuvarauksen, loitsun kesto kasvaa 24 tuntiin. Jos loitsit tämän loitsun käyttäen yhdeksännen piirin loitsuvarauksen, loitsu kestää siihen saakka kun se puretaan. Käyttämällä viidennen piirin tai korkeamman loitsuvarauksen, loitsu ei vaadi enää keskittymistä.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kirouksen kumoaminen](Kirouksen_kumoaminen.md)
+
+Seuraava [Kiveen sulautuminen](Kiveen_sulautuminen.md)

--- a/Loitsut/Kiveen_sulautuminen.md
+++ b/Loitsut/Kiveen_sulautuminen.md
@@ -1,0 +1,25 @@
+### Kiveen sulautuminen
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** 8 tuntia
+
+Voit astua sisälle vähintään itsesi kokoiseen kiveen, kallioon tai kiviseen esineeseen sulautuen varusteittesi kera kiveen. Sinusta ei jää mitään näkyville, ja sinua ei voi havaita tavanomaisin keinoin.
+
+Kun olet kiveen sulautuneena, et voi nähdä mitä sen ulkopuolella tapahtuu ja saat kuuntelemiseen liittyviin viisaus (tarkkaavaisuus) heittoihin *haitan*. Pysyt selvillä ajan kulusta ja voit loitsia niitä loitsuja, joiden kohteena olet sinä itse. Voit astua ulos kivestä samasta kohtaa kuin menit sisäänkin, mutta et voi muuten liikkua kiven sisällä.
+
+Pienet vahingot kiven pintaan eivät vahingoita sinua, mutta jos kiveä tuhotaan niin paljon, että tulet esille, kärsit 6n6 pistettä murskausvahinkoa. Kiven tuhoaminen kokonaan aiheuttaa 50 pistettä murskausvahinkoa sinulle. Putoat samalla vapaaseen kohtaan mahdollisimman lähelle kiveä. Tämän lisäksi olet *maissa*.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kirous](Kirous.md)
+
+Seuraava [Kuolleille puhuminen](Kuolleille_puhuminen.md)

--- a/Loitsut/Kuolleille_puhuminen.md
+++ b/Loitsut/Kuolleille_puhuminen.md
@@ -1,0 +1,21 @@
+### Kuolleille puhuminen
+
+*3-piirin kuolontaikuus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 4 metriä
+
+**Komponentit:** taikasana, ele, aines (palava suitsuke)
+
+**Kesto:** 10 minuuttia
+
+Annat ruumiille loitsun kantamalla väliaikaisen epäelon kipinän, jotta se voi vastata kysymyksiisi. Tuolla ruumiilla tulee olla suu, eikä se saa olla epäkuollut. Loitsu epäonnistuu, jos ruumis on ollut tämän loitsun kohteena viimeisen 10 päivän aikana. Loitsun päättymiseen asti voit kysyä ruumiilta korkeintaan viisi kysymystä. Ruumis tietää ainoastaan asioita, joita se tiesi eläessään ja se osaa vain kieliä, joita se osasi puhua eläessään. Vastaukset ovat yleensä lyhyitä, epäselviä ja toistavat itseään, ja mikään ei pakota ruumista vastaamaan totuudenmukaisesti, jos se tunnistaa sinut vihamieliseksi tai viholliseksi. ***Kuolleille puhuminen*** ei palauta kuolleen sielua ruumiiseen, vaan ainoastaan herättää rajoitetusti sen ruumiin. Täten ruumis ei voi oppia uutta tai pohtia tulevia tapahtumia, eikä se tiedä mitään tapahtumista sen kuoleman jälkeen.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kiveen sulautuminen](Kiveen_sulautuminen.md)
+
+Seuraava [Kuvajainen](Kuvajainen.md)

--- a/Loitsut/Kuvajainen.md
+++ b/Loitsut/Kuvajainen.md
@@ -1,0 +1,27 @@
+### Kuvajainen
+
+*3-piirin illuusio* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 48 metriä
+
+**Komponentit:** taikasana, ele, aines (hieman villaa)
+
+**Kesto:** keskittyminen, korkeintaan 10 minuuttia
+
+Luot kuvajaisen esineestä, olennosta tai jostain näkyvästä ilmiöstä, joka ei ole suurempi kuin 8x8x8 metrin kuutio. Kuvajainen ilmestyy haluamaasi kohtaan kantamalla ja kestää loitsun keston ajan. Se haisee, kuulostaa, näyttää ja tuntuu jopa oikean lämpöiseltä. Et voi kuitenkaan tehdä kuvajaista, joka aiheuttaa vahinkoa tai muuta haittaa lämmöllä, kylmyydellä, kovalla äänellä tai pahalla hajullaan.
+
+Niin kauan kuin pidät illuusion kantamalla, voit käyttää toiminnon sen siirtämiseen toiseen kohtaan kantamalla. Voit saada kuvajaisen liikkeen näyttämään aidolta (esimerkiksi kävelyltä). Voit myös laittaa kuvajaisen tuottamaan ääniä eri aikaan, jolloin saat sen esimerkiksi keskustelemaan jonkun kanssa.
+
+Jos joku koskee kuvajaiseen, se paljastuu illuusioksi, koska sen läpi voi kulkea. Jos olento tarkastelee kuvajaista, sille paljastuu asioiden todellinen laita onnistuneella älykkyys (tutkimus) heitolla sinun loitsujesi pelastusheiton vaikeusastetta vastaan. Olennon tajutessa kuvajaisen olevan illuusio, se näkee saman tien sen läpi eikä kuvajaisen ääni, lämpö tai haju enää vaikuta siihen.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit tämän loitsun käyttäen kuudennen tai sitä korkeamman piirin loitsuvarauksen, loitsu kestää siihen asti kun se puretaan, eikä loitsun ylläpito vaadi keskittymistä sinulta.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kuolleille puhuminen](Kuolleille_puhuminen.md)
+
+Seuraava [Lento](Lento.md)

--- a/Loitsut/Lento.md
+++ b/Loitsut/Lento.md
@@ -1,0 +1,23 @@
+### Lento
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele, aines (minkä tahansa linnun siipisulka)
+
+**Kesto:** keskittyminen, enintään 10 minuuttia
+
+Kosketat vapaaehtoista olentoa. Kohde saa 24 metrin lentonopeuden loitsun keston ajaksi. Loitsun päättyessä kohde putoaa, jos hän on yhä ilmassa tai ei kykene estämään putoamista.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit lennon käyttäen neljännen tai korkeamman piirin loitsuvarausta, voit ottaa kohteeksi yhden ylimääräisen olennon jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Kuvajainen](Kuvajainen.md)
+
+Seuraava [Löyhkäävä pilvi](Löyhkäävä_pilvi.md)

--- a/Loitsut/Loitsut.md
+++ b/Loitsut/Loitsut.md
@@ -5,3 +5,4 @@ Seuraavilla sivuilla löydät kuvaukset kaikista tunnetuista loitsuista. Loitsut
 * [Taikakonstit](0_piirin_taikakonstit.md)
 * [Ensimmäisen piirin loitsut](1_piirin_loitsut.md)
 * [Toisen piirin loitsut](2_piirin_loitsut.md)
+* [Kolmannen piirin loitsut](3_piirin_loitsut.md)

--- a/Loitsut/Löyhkäävä_pilvi.md
+++ b/Loitsut/Löyhkäävä_pilvi.md
@@ -1,0 +1,25 @@
+### Löyhkäävä pilvi
+
+*3-piirin kutsuminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 36 metriä
+
+**Komponentit:** taikasana, ele, aines (mädäntynyt muna tai haisevaa kaalia)
+
+**Kesto:** keskittyminen, korkeintaan 1 minuutin
+
+Luot säteeltään 8 metrin kokoisen löyhkäävän keltaisen pilvipallon, jonka keskipiste on jossain loitsun kantamalla. Pilvi leviää kulmien ympäri ja sen vaikutusalueella on peittynyt näkyvyys. Pilvi pysyy paikallaan loitsun keston ajan.
+
+Jokaisen olennon, jonka pilvi peittää kokonaan vuoronsa alussa, täytyy heittää sitkeys-pelastusheitto myrkkyä vastaan. Epäonnistuessaan olennon vuoro menee yskiessä ja kakoessa. Olennot, joiden ei tarvitse hengittää tai jotka ovat immuuneja myrkylle, onnistuvat automaattisesti pelastusheitossa. 
+
+Kohtalainen tuuli (ainakin 5 m/s) hajottaa pilven neljässä kierroksessa ja kova tuuli (yli 10 m/s) hajottaa sen 1 kierroksessa.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Lento](Lento.md)
+
+Seuraava [Maja](Maja.md)

--- a/Loitsut/Maja.md
+++ b/Loitsut/Maja.md
@@ -1,0 +1,25 @@
+### Maja
+
+*3-piirin luominen (rituaali)* 
+
+**Loitsimisviive:** 1 minuutti
+
+**Kantama:** itse (4 metriä säteeltään oleva puolipallo)
+
+**Komponentit:** taikasana, ele, aines (pieni kristallihelmi)
+
+**Kesto:** 8 tuntia
+
+Neljä metriä säteeltään oleva läpäisemätön puolipallon muotoinen kupu ilmestyy sinun ympärillesi loitsun keston ajaksi. Loitsu päättyy, jos lähdet sen vaikutusalueelta.
+
+Kuvun alle mahtuu sinun lisäksi yhdeksän pientä tai keskikokoista olentoa. Loitsu epäonnistuu, jos sen loitsimishetkellä vaikutusalueella on liian iso olento tai enemmän kuin yhdeksän olentoa. Olennot ja esineet, jotka olivat kuvun sisällä loitsimishetkellä, voivat liikkua vapaasti sisään ja ulos siitä. Kaikille muille kupu on läpäisemätön. Loitsut ja maagiset vaikutukset eivät voi läpäistä kuvun kuorta. Ilma kuvun sisällä on kuivaa ja miellyttävää riippumatta siitä, minkälainen ilma sen ulkopuolella on.
+
+Loitsun päättymiseen asti voit komennolla muuttaa halutessasi valaistusta kuvun sisällä valoisammaksi tai pimeämmäksi. Kuvusta näkee läpi ulkopuolelle, mutta sen sisälle ei näe ulkopuolelta.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Löyhkäävä pilvi](Löyhkäävä_pilvi.md)
+
+Seuraava [Myrskyvalli](Myrskyvalli.md)

--- a/Loitsut/Myrskyvalli.md
+++ b/Loitsut/Myrskyvalli.md
@@ -1,0 +1,25 @@
+### Myrskyvalli
+
+*3-piirin luominen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 48 metriä
+
+**Komponentit:** taikasana, ele, aines (pieni viuhka ja eksoottisen alkuperän sulka)
+
+**Kesto:** keskittyminen, enintään 1 minuutti
+
+Luot loitsun kantamalle voimakkaan tuulen muodostaman esteen, myrskyvallin. Voit tehdä myrskyvallista 20 metriä pitkän, 3-4 metriä korkean ja noin 30 cm paksun. Esteen muoto voi olla minkälainen tahansa, kunhan se on yhtenäisenä linjana.
+
+Myrskyvallin ilmestyessä kaikki sen alueella olevat olennot joutuvat heittämään voimakkuus-pelastusheiton. Pelastusheitossa epäonnistuneet kärsivät 3n8 murskausvahinkoa, ja onnistuminen puolittaa vahingon. 
+
+Voimakas tuuli pitää kaikki kaasut, savun ja sumun loitolla. Kevyet irtonaiset tavarat, jotka osuvat myrskyvalliin, lentävät ylöspäin. Keihäät, lingonkivet, heittokirveet, nuolet, vaarnat ja kaikki muut tavanomaiset ammukset ja heittoaseet pysähtyvät myrskyvalliin ja lentävät ylös. Niillä ei voi ampua myrskyvallin läpi (jättiläisten heittämät kivet ja piirityslaitteiden laukaisemat ammukset menevät kuitenkin läpi tavalliseen tapaan). Kaasumuodossa olevat olennot eivät voi kulkea myrskyvallin läpi.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Maja](Maja.md)
+
+Seuraava [Parannuksen mahtisana](Parannuksen_mahtisana.md)

--- a/Loitsut/Parannuksen_mahtisana.md
+++ b/Loitsut/Parannuksen_mahtisana.md
@@ -1,0 +1,23 @@
+### Parannuksen mahtisana
+
+*3-piirin luominen* 
+
+**Loitsimisviive:** 1 bonustoiminto
+
+**Kantama:** 24 metriä
+
+**Komponentit:** taikasana
+
+**Kesto:** välitön
+
+Lausut ääneen mahtisanan, joka parantaa liittolaisiasi. Enintään kuusi valitsemaasi olentoa loitsun kantamalla näköpiirissäsi saa jokainen takaisin 1n4+loitsimisominaisuutesi muuttujan verran osumapisteitä.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit parannuksen mahtisanan käyttäen neljännen tai korkeamman piirin loitsuvarausta, se parantaa 1n4 osumapistettä lisää jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Myrskyvalli](Myrskyvalli.md)
+
+Seuraava [Pelko](Pelko.md)

--- a/Loitsut/Pelko.md
+++ b/Loitsut/Pelko.md
@@ -1,0 +1,21 @@
+### Pelko
+
+*3-piirin illuusio* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** itse (12 metrin kokoinen kartio)
+
+**Komponentit:** taikasana, ele, aines (valkoinen sulka tai kanan sydän)
+
+**Kesto:** keskittyminen, korkeintaan 1 minuutin
+
+Luot aavemaisen kuvan olennon pahimmasta pelosta. Jokaisen olennon, joka on sinusta lähtevässä 12 metrin mittaisessa kartiossa täytyy heittää viisaus-pelastusheitto Epäonnistuessaan olento pudottaa kädessään olevat tavarat ja on *kauhistunut* loitsun keston ajan. Ollessaan *kauhistunut*, olennon täytyy joka vuorollaan tehdä ryntäystoiminto ja liikkua poispäin sinusta turvallista reittiä pitkin. Jos olento päätyy liikkeen päättyessä paikkaan, jossa se ei enää näe sinua, se voi heittää viisaus-pelastusheiton. Onnistuessaan pelastusheitossa, loitsun vaikutus lakkaa sen osalta.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Parannuksen mahtisana](Parannuksen_mahtisana.md)
+
+Seuraava [Päivänvalo](Päivänvalo.md)

--- a/Loitsut/Päivänvalo.md
+++ b/Loitsut/Päivänvalo.md
@@ -1,0 +1,26 @@
+### Päivänvalo
+
+*3-piirin luominen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 24 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** 1 tunti
+
+Valitse piste jostain loitsun kantamalta. Tuosta pisteestä lähtee kirkas valo 24 metrin säteelle joka suuntaan ja himmeä valo säteen reunalta 24 metriä ulospäin.
+
+Jos valitset pisteeksi jonkin esineen, jota kannat tai joka ei ole kenenkään muun kantama, valo liikkuu tuon esineen mukana. Jos kyseisen esineen peittää kokonaan, peittyy samalla myös valo.
+
+Jos tämän loitsun vaikutus osuu kolmannen tai matalamman piirin ***pimeys***-loitsun vaikutusalueelle, ***pimeys***-loitsu purkautuu.
+
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Pelko](Pelko.md)
+
+Seuraava [Räntäsade](Räntäsade.md)

--- a/Loitsut/Räntäsade.md
+++ b/Loitsut/Räntäsade.md
@@ -1,0 +1,25 @@
+### Räntäsade
+
+*3-piirin kutsuminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 60 metriä
+
+**Komponentit:** taikasana, ele, aines (ripaus tomua ja muutama tippa vettä)
+
+**Kesto:** keskittyminen, korkeintaan 1 minuutin
+
+Loitsun keston ajan sataa jäistä vettä ja räntää haluamallesi sijainnille loitsun kantamalla. ***Räntäsade***-loitsun vaikutusalue on 8 metriä korkea ja se on pyöreä alue, jonka säde on 16 metriä. Alueella on peittynyt näkyvyys ja kaikki esillä olevat tulet sammuvat siellä.
+
+Alue peittyy liukkaaseen jäähän ja se muuttuu vaikeaksi maastoksi. Olennon täytyy heittää ketteryys-pelastusheitto mennessään loitsun vaikutusalueelle tai päättäessään vuoronsa siellä. Pelastusheiton epäonnistuessa olento kaatuu ja on *maissa*. 
+
+Jos olento yrittää keskittyä loitsun vaikutusalueella, sen tulee heittää sitkeys-pelastusheitto loitsusi VA:ta vastaan. Pelastusheiton epäonnistuessa keskittyminen katkeaa.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Päivänvalo](Päivänvalo.md)
+
+Seuraava [Salama](Salama.md)

--- a/Loitsut/Salama.md
+++ b/Loitsut/Salama.md
@@ -1,0 +1,25 @@
+### Salama
+
+*3-piirin luominen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** itse (40 metriä pitkä linja)
+
+**Komponentit:** taikasana, ele, aines (turkispala ja pieni meripihka-, kristalli- tai lasisauva)
+
+**Kesto:** välitön
+
+Salama lyö sinusta lähtevänä 40 metrin linjana haluamaasi suuntaan. Kaikki alueella olevat olennot joutuvat heittämään ketteryys-pelastusheiton. Epäonnistuneet kärsivät 8n6 salamavahinkoa, ja onnistuminen puolittaa vahingon.
+
+Salama sytyttää tuleen kaikki alueella olevat syttyvät esineet, jotka eivät ole jonkun varusteita tai kantamina.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit salaman käyttäen neljännen tai korkeamman piirin loitsuvarausta, vahinko nousee 1n6 jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla (esim. Neljännen piirin loitsuvaraus toisi 1n6 lisää vahinkoa ja seitsemännen piirin loitsuvaraus 4n6 lisää). 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Räntäsade](Räntäsade.md)
+
+Seuraava [Selvännäkeminen](Selvännäkeminen.md)

--- a/Loitsut/Selvännäkeminen.md
+++ b/Loitsut/Selvännäkeminen.md
@@ -1,0 +1,25 @@
+### Selvännäkeminen
+
+*3-piirin ennustaminen* 
+
+**Loitsimisviive:** 10 minuuttia
+
+**Kantama:** 2 kilometriä
+
+**Komponentit:** taikasana, ele, aines (vähintään 100 kultarahan arvoinen fokus, joko jalokivin koristeltu kuulotorvi tai lasisilmä)
+
+**Kesto:** keskittyminen, enintään 10 minuuttia
+
+Luot näkymättömän anturin kantaman sisällä joko sinulle ennestään tuttuun sijaintiin tai ilmeiseen sijaintiin, kuten lukitun oven taakse. Tämä anturi pysyy paikallaan keston ajan, ja sen kimppuun ei voida käydä tai sen kanssa ei voi olla vuorovaikutuksessa.
+
+Loitsiessasi valitse näön tai kuulon välillä. Voit käyttää valitsemaasi aistia kuin olisit anturin sijainnissa. Voit toiminnolla vaihtaa näön ja kuulon välillä.
+
+Olento, joka voi nähdä *näkymättömän* esimerkiksi *tosinäöllä* tai loitsuilla kuten ***näkymättömän näkeminen***, näkee anturin kohdalla nyrkinkokoisen hohtavan ja läpikuultavan pallomaisen möykyn.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Salama](Salama.md)
+
+Seuraava [Suoja energialta](Suoja_energialta.md)

--- a/Loitsut/Suoja_energialta.md
+++ b/Loitsut/Suoja_energialta.md
@@ -1,0 +1,21 @@
+### Suoja energialta
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** keskittyminen, korkeintaan 1 tunnin
+
+Loitsun keston ajan vapaaehtoisella olennolla on sietokyky valitsemaasi vahinkotyyppiä vastaan (joko happovahinko, jäävahinko, tulivahinko, salamavahinko tai ukkosvahinko).
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Selvännäkeminen](Selvännäkeminen.md)
+
+Seuraava [Suojelushenget](Suojelushenget.md)

--- a/Loitsut/Suojelushenget.md
+++ b/Loitsut/Suojelushenget.md
@@ -1,0 +1,23 @@
+### Suojelushenget
+
+*3-piirin kutsuminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** itse (6 metrin säteellä sinusta)
+
+**Komponentit:** taikasana, ele, aines (pyhä symboli)
+
+**Kesto:** keskittyminen, enintään 10 minuuttia
+
+Kutsut henkiä suojelemaan sinua. Ne liikkuvat kuuden metrin säteellä sinusta. Jos olet hyvä tai neutraali, ne näyttävät ulkomuodoltaan enkeli- tai keijumaisilta valintasi mukaan. Jos olet paha, ne näyttävät pirullisilta. Kun loitsit ***suojelushenget***, voit määrittää minkä tahansa määrän olentoja, joihin se ei vaikuta. Niiden, joihin loitsu vaikuttaa, nopeus puolittuu vaikutusalueella. Lisäksi olennon liikkuessa sisään vaikutusalueelle tai aloittaessa vuoronsa siellä tämän täytyy heittää viisaus-pelastusheitto. Epäonnistuessaan pelastusheitossa olento kärsii 3n8 hohkavahinkoa, jos olet hyvä tai neutraali tai 3n8 kuolonvahinkoa, jos olet paha. Onnistuminen puolittaa vahingon.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit suojelushen- get käyttäen neljännen tai korkeamman piirin loitsuvarausta, vahinko nousee in8 jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Suoja energialta](Suoja_energialta.md)
+
+Seuraava [Taikakehä](Taikakehä.md)

--- a/Loitsut/Taikakehä.md
+++ b/Loitsut/Taikakehä.md
@@ -1,0 +1,31 @@
+### Taikakehä
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 minuutti
+
+**Kantama:** 4 metriä
+
+**Komponentit:** taikasana, ele, aines (pyhää vettä tai hopeajauhetta ja rautaa vähintään 100 kr edestä, jotka loitsu kuluttaa)
+
+**Kesto:** 1 tunti
+
+Luot 4 metriä säteeltään ja 8 metriä korkean sylinterinmuotoisen, maagista energiaa sisältävän alueen johonkin loitsun kantamalla. Jos sylinterin alareuna koskee maata, seinää tai muuta pintaa, siihen ilmestyy hohtavia maagisia riimuja.
+
+Valitse yksi seuraavista olentotyypeistä: taivaallinen olento, elementaali, keiju, piru tai epäkuollut. Taikakehä vaikuttaa seuraavilla tavoilla kyseisen olentotyypin edustajiin:
+
+ - Olento ei voi vapaaehtoisesti mennä taikakehän sisään ei-maagisin keinoin. Jos olento yrittää teleportata alueelle tai siirtyä sinne maailmatasojen välillä, sen tulee ensin onnistua karisma-pelastusheitossa.
+ - Olennolla on *haitta* hyökkäysheittoihin taikakehän sisällä olevia kohteita vastaan.
+ - Taikakehän sisällä olevia kohteita ei voi *lumota*, *pelotella* tai ottaa valtaansa kyseisen olennon toimesta.
+ 
+Voit myös päättää loitsia tämä loitsun päinvastoin, jolloin estät kyseisen olennon pääsyn pois taikakehästä ja suojelet sen ulkopuolella olevia.
+
+**Korkeammilla loitsuvarauksilla.** Jos loitsit tämän loitsun käyttäen neljännen tai sitä korkeamman piirin loitsuvarauksen, loitsun kesto kasvaa tunnilla jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Suojelushenget](Suojelushenget.md)
+
+Seuraava [Taikaratsu](Taikaratsu.md)

--- a/Loitsut/Taikaratsu.md
+++ b/Loitsut/Taikaratsu.md
@@ -1,0 +1,23 @@
+### Taikaratsu
+
+*3-piirin illuusio (rituaali)* 
+
+**Loitsimisviive:** 1 minuutti
+
+**Kantama:** 12 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** 1 tunti
+
+Suurikokoinen, vain osittain konkreettinen hevosen kaltainen olento putkahtaa olemassaoloon lähimmässä valitsemassasi vapaassa tilassa, johon se loitsun kantamalla mahtuu. Päätät olennon ulkonäöstä itse ja se tulee varustettuna satulalla ja suitsilla. Satula ja suitset katoavat savunpöllähdyksenä ilmaan, jos ne viedään neljää metriä kauemmaksi olennosta.
+
+Loitsun keston ajan valitsemasi olento voi ratsastaa tällä olennolla. Taikaratsu käyttää ratsuhevosen kykylistausta sillä erotuksella, että sen nopeus on 40 metriä ja se voi liikkua vauhdilla 16 tai 25 kilometriä tunnissa. Loitsun keston kuluessa loppuun ratsuu hiipuu pois hitaasti antaen ratsastajalle yhden minuutin aikaa laskeutua pois ratsailta. Loitsu päättyy, jos käytät toiminnon sen päättämiseen tai jos taikaratsu kärsii yhtään vahinkoa. 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Taikakehä](Taikakehä.md)
+
+Seuraava [Taikuuden purkaminen](Taikuuden_purkaminen.md)

--- a/Loitsut/Taikuuden_purkaminen.md
+++ b/Loitsut/Taikuuden_purkaminen.md
@@ -1,0 +1,23 @@
+### Taikuuden purkaminen
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 48 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** välitön
+
+Valitse loitsun kohteeksi yksi olento, esine tai maaginen vaikutus loitsun kantamalla. Mikä tahansa loitsun vaikutus, joka on kolmannelta tai matalammalta piiriltä päättyy välittömästi. Joudut tekemään ominaisuusheiton käyttäen loitsimisominaisuuttasi loitsua vastaan, joka on neljänneltä tai korkeammalta piiriltä. Tämän heiton VA on 10+purettavan loitsun piiri. Onnistuneella ominaisuusheitolla kohteena oleva loitsu päättyy.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit taikuuden purkamisen käyttäen neljännen tai korkeamman piirin loitsuvarausta, se purkaa kohteena olevan loitsun automaattisesti, jos kyseinen loitsu on samaa piiriä tai matalammalta kuin käytetty loitsuvaraus. 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Taikaratsu](Taikaratsu.md)
+
+Seuraava [Toivon majakka](Toivon_majakka.md)

--- a/Loitsut/Toivon_majakka.md
+++ b/Loitsut/Toivon_majakka.md
@@ -1,0 +1,21 @@
+### Toivon majakka
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 12 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** keskittyminen, enintään 1 minuutti
+
+Tämä loitsu palauttaa toivon ja elämänhalun. Valitse mikä tahansa määrä olentoja loitsun kantamalla. Loitsun keston ajan heistä jokaisella on *etu* viisaus-pelastusheitoissa ja pelastusheitoissa kuolemaa vastaan. He saavat myös kaikesta parantamisesta suurimman mahdollisen määrän osumapisteitä takaisin.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Taikuuden purkaminen](Taikuuden_purkaminen.md)
+
+Seuraava [Torjuva merkki](Torjuva_merkki.md)

--- a/Loitsut/Torjuva_merkki.md
+++ b/Loitsut/Torjuva_merkki.md
@@ -1,0 +1,35 @@
+### Torjuva merkki
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 tunti
+
+**Kantama:** kosketus
+
+**Komponentit:** taikasana, ele, aines (suitsuketta ja timanttipölyä ainakin 200 kr edestä, jotka loitsu kuluttaa)
+
+**Kesto:** kunnes puretaan tai loitsu laukeaa
+
+Loitsiessasi tämän loitsun luot merkin johonkin pintaan (esimerkiksi seinään tai lattiaan) tai esineeseen, jonka voi avata ja sulkea (esimerkiksi kirja, käärö tai aarrearkku). Jos valitset jonkin pinnan, merkki voi kattaa korkeintaan 4x4 metrin kokoisen alueen. Jos valitset esineen, tulee esineen pysyä lähes paikallaan, jotta merkki toimii. Loitsu raukeaa, jos esine viedään yli neljän metrin päähän paikasta, jossa merkki loitsittiin.
+
+Torjuva merkki on heikosti näkyvä ja sen löytämiseen tarvitsee onnistuneen älykkyys (tutkimus) heiton loitsun VA:ta vastaan.
+
+Saat loitsiessasi päättää, mikä torjuvan merkin laukaisee. Pin toihin laitetut merkit laukeavat yleensä joko, jos niitä koskee, jos niiden päällä seisoo, jos niitä lähestyy tai jos siirtää jonkin esineen pois pinnalta. Esineeseen liitetyt merkit laukeavat yleensä joko esineen avaamisesta, sen lähestymisestä tai merkin näkemisestä.
+
+Voit myös hienosäätää merkkiä niin, että se laukeaa vain tietyissä olosuhteissa, tiettyjen fyysisten ehtojen täyttyessä (kuten pituus ja paino), lajin mukaan (esimerkiksi se vaikuttaa vain. alishaltioihin tai epäsikiöihin) tai vakaumuksen mukaan. Voit myös määrittää jonkin ehdon, jolloin merkki ei laukea (esimerkiksi salasanan ääneen lausumisen).
+
+Tehdessäsi merkin saat valita onko se **räjähtävä merkki** vai **loitsumerkki**.
+
+**Räjähtävä merkki.** Lauetessaan merkistä räjähtää maagista energiaa 8 metrin säteelle pallomaisena muotona. Räjähtävän pallon energia ulottuu myös kulmien taakse. Jokaisen alueella olevan olennon täytyy heittää ketteryys-pelastusheitto. Epäonnistuessaan olento kärsii 5n8 pistettä happo-, jää-, tuli-, salama- tai ukkosvahinkoa (saat valita vahingon tyypin merkin teon yhteydessä). Onnistuminen puolittaa vahingon.
+
+**Loitsumerkki.** Voit loitsia korkeintaan kolmannen piirin loitsun osaksi merkkiä sen loitsimisen yhteydessä. Tuon loitsun tulee olla sellainen, joka kohdistuu joko yhteen olentoon tai alueeseen. Merkkiin varastoitu loitsu alkaa vaikuttaa loitsumerkin laukeamisen yhteydessä. Jos loitsu kohdistuu yhteen olentoon, sen kohde on olento, joka laukaisi merkin. Jos loitsulla on aluevaikutus, alueen keskipiste on olento, joka laukaisi merkin. Jos loitsu kutsuu olentoja tai luo esineitä tai ansoja, ne ilmestyvät mahdollisimman lähelle merkin laukaissutta olentoa. Jos loitsu on keskittymistä vaativa, se kestää täyden kestonsa ajan.
+
+**Korkeammilla loitsuvarauksilla.** Jos loitsit tämän loitsun käyttäen neljännen tai sitä korkeamman piirin loitsuvarauksen, räjähtävän merkin vahinko kasvaa 1n8 pisteellä jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla. Jos teet loitsumerkin, voit tallettaa siihen käyttämääsi loitsuvarauksen piiriä vastaavan loitsun.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Toivon majakka](Toivon_majakka.md)
+
+Seuraava [Tulipallo](Tulipallo.md)

--- a/Loitsut/Tulipallo.md
+++ b/Loitsut/Tulipallo.md
@@ -1,0 +1,23 @@
+### Tulipallo
+
+*3-piirin luominen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 60 metriä
+
+**Komponentit:** taikasana, ele, aines (pieni pallo lepakon guanoa ja rikkiä)
+
+**Kesto:** välitön
+
+Kirkas valojuova suhahtaa sormella osoittamaasi pisteeseen loitsun kantamalla ja räjähtää sinne osuttuaan liekkien pyrskeeksi. Pallon muotoinen räjähdys ulottuu 4 metrin päähän osumakohdasta. Kaikki vaikutusalueella olevat olennot joutuvat heittämään ketteryys-pelastusheiton. Epäonnistuneet kärsivät 8n6 tulivahinkoa, ja onnistuminen puolittaa vahingon. Tuli leviää nurkkien ja kulmien ympäri. Kaikki alueella olevat syttyvät esineet, jotka eivät ole jonkun varusteita tai kantamia, syttyvät tuleen.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit tulipallon käyttäen neljännen tai korkeamman piirin loitsuvarausta, vahinko nousee 1n6 jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla (esim. Neljännen piirin loitsuvaraus toisi 1n6 lisää vahinkoa ja seitsemännen piirin loitsuvaraus 4n6 lisää). 
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Torjuva merkki](Torjuva_merkki.md)
+
+Seuraava [Ukkosen kutsuminen](Ukkosen_kutsuminen.md)

--- a/Loitsut/Ukkosen_kutsuminen.md
+++ b/Loitsut/Ukkosen_kutsuminen.md
@@ -1,0 +1,25 @@
+### Ukkosen kutsuminen
+
+*3-piirin kutsuminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 48 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** keskittyminen, enintään 10 minuuttia
+
+Sylinterin muotoinen, 4 metriä halkaisijaltaan oleva myrskypilvi ilmestyy pisteeseen loitsun kantamalla, jonka voit nähdä ja joka on 30 metriä yläpuolellasi. Jos et pysty näkemään tarpeeksi korkealla olevaan pisteeseen, loitsu epäonnistuu automaattisesti (esimerkiksi, jos olet matalassa huoneessa).
+
+Kun loitsit ukkosen kutsumisen, valitse piste loitsun kantamalla, johon sinulla on näköyhteys. Jokainen olento kahden metrin etäisyydellä valitsemastasi pisteestä joutuu heittämään ketteryys-pelastusheiton. Epäonnistuneet kärsivät 3n10 salamavahinkoa, ja onnistuminen puolittaa vahingon. Jokaisella vuorollasi voit loitsun keston aikana kutsua salamoita vastaavalla tavalla joko samaan tai johonkin toiseen pisteeseen loitsun kantamalla. Jos ulkona on ukonilma kun loitsit ukkosen kutsumisen, loitsu ei luo myrskypilveä vaan antaa olemassa olevan myrskyn komentoosi, jolloin voit kutsua siitä salamoita. Näissä olosuhteissa salaman vahinko myös nousee 1n10 pisteellä ollen 4n10.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit ukkosen kutsumisen käyttäen neljännen tai korkeamman piirin loitsuvarausta, vahinko nousee 1n10 jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Tulipallo](Tulipallo.md)
+
+Seuraava [Vampyyrikosketus](Vampyyrikosketus.md)

--- a/Loitsut/Vampyyrikosketus.md
+++ b/Loitsut/Vampyyrikosketus.md
@@ -1,0 +1,23 @@
+### Vampyyrikosketus
+
+*3-piirin kuolontaikuus* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** itse
+
+**Komponentit:** taikasana, ele, aines
+
+**Kesto:** keskittyminen, enintään 1 minuutti
+
+Varjojen verhoama kätesi ryövää muiden elämänenergiaa parantaen omia haavojasi koskettaessasi heitä. Tee lähitaisteluhyökkäys olentoon, joka on ulottuvillasi. Osuessasi aiheutat 3n6 kuolonvahinkoa ja itseltäsi paranee osumapisteitä puolet aiheuttamastasi vahingosta.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit vampyyrikosketuksen käyttäen neljännen tai korkeamman piirin loitsuvarausta, vahinko nousee 1n6 jokaista loitsuvarauksen piiriä kohden, joka on kolmatta piiriä korkeammalla.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Ukkosen kutsuminen](Ukkosen_kutsuminen.md)
+
+Seuraava [Vastaloitsu](Vastaloitsu.md)

--- a/Loitsut/Vastaloitsu.md
+++ b/Loitsut/Vastaloitsu.md
@@ -1,0 +1,23 @@
+### Vastaloitsu
+
+*3-piirin suojelus* 
+
+**Loitsimisviive:** 1 reaktio, kun näet olennon 24 metrin etäisyydellä sinusta loitsivan
+
+**Kantama:** 24 metriä
+
+**Komponentit:** taikasana
+
+**Kesto:** välitön
+
+Yrität keskeyttää jonkun toisen loitsimisen. Kohteen loitsiessa kolmannen tai matalamman piirin loitsua onnistut keskeyttämään sen ja loitsulla ei ole vaikutusta. Joudut tekemään ominaisuusheiton käyttäen loitsimisominaisuuttasi loitsua vastaan, joka on neljänneltä tai korkeammalta piiriltä. Tämän heiton VA on 10+purettavan loitsun piiri. Onnistuneella ominaisuusheitolla kohteena oleva loitsu keskeytyy ja sillä ei ole vaikutusta.
+
+**Korkeammilla loitsuvarauksilla.** Kun loitsit vastaloitsun käyttäen neljännen tai korkeamman piirin loitsuvarausta, keskeytetyllä loitsulla ei ole vaikutusta, jos se on saman tai matalamman piirin loitsu kuin loitsuvaraus, jonka käytit.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Vampyyrikosketus](Vampyyrikosketus.md)
+
+Seuraava [Veden hengittäminen](Veden_hengittäminen.md)

--- a/Loitsut/Veden_hengittäminen.md
+++ b/Loitsut/Veden_hengittäminen.md
@@ -1,0 +1,21 @@
+### Veden hengittäminen
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 12 metriä
+
+**Komponentit:** taikasana, ele, aines (ruoko tai olki)
+
+**Kesto:** 24 tuntia
+
+Tämä loitsu antaa kyvyn hengittää veden alla. Korkeintaan kymmenen vapaaehtoista olentoa loitsun kantamalla, joihin sinulla on näköyhteys, saa kyvyn hengittää veden alla. Loitsun kohteilla säilyy myös normaali kykynsä hengittää (he eivät tukehdu veden ulkopuolella).
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Vastaloitsu](Vastaloitsu.md)
+
+Seuraava [Veden ja ruoan luominen](Veden_ja_ruoan_luominen.md)

--- a/Loitsut/Veden_ja_ruoan_luominen.md
+++ b/Loitsut/Veden_ja_ruoan_luominen.md
@@ -1,0 +1,21 @@
+### Veden ja ruoan luominen
+
+*3-piirin kutsuminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 12 metriä
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** välitön
+
+Luot 20 kiloa ruokaa ja 120 litraa vettä joko loitsun kantamalla oleviin astioihin tai maahan. Ruokaa ja juomaa on riittävästi, että 15 humanoidia tai viisi ratsua pärjää sillä 24 tuntia. Ruoka on mautonta, mutta ravitsevaa. Ruoka pilaantuu, jos sitä ei syödä 24 tunnin aikana. Vesi on puhdasta ja ei pilaannu 24 tunnin kuluttua.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Veden hengittäminen](Veden_hengittäminen.md)
+
+Seuraava [Vetten päällä kävely](Vetten_päällä_kävely.md)

--- a/Loitsut/Vetten_päällä_kävely.md
+++ b/Loitsut/Vetten_päällä_kävely.md
@@ -1,0 +1,21 @@
+### Vetten päällä kävely
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** 12 metriä
+
+**Komponentit:** taikasana, ele, aines (korkinpala)
+
+**Kesto:** 1 tunti
+
+Tämä loitsu antaa kyvyn liikkua veden ja muiden nestemäisessä tai juoksevassa muodossa olevien upottavien aineiden (esim. hapon, mudan, lumen, juoksuhiekan tai laavan) yli. Laavan yli liikkuessa tosin sen säteilemä kuumuus voi silti vahingoittaa. Korkeintaan kymmenen vapaaehtoista olentoa loitsun kantamalla, joihin sinulla on näköyhteys, saa tämän kyvyn. Loitsittaessa kohteeseen, joka on veden tai muun upottavan aineen alla, tämä nousee ylös 18 metriä kierroksessa, kunnes on vedenpinnan (tai muun nesteen) yläpuolella.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Veden ja ruoan luominen](Veden_ja_ruoan_luominen.md)
+
+Seuraava [Vilahdus](Vilahdus.md)

--- a/Loitsut/Vilahdus.md
+++ b/Loitsut/Vilahdus.md
@@ -1,0 +1,24 @@
+### Vilahdus
+
+*3-piirin muovaaminen* 
+
+**Loitsimisviive:** 1 toiminto
+
+**Kantama:** itse
+
+**Komponentit:** taikasana, ele
+
+**Kesto:** 1 minuutti
+
+Heitä loitsun keston ajan n20 jokaisen vuorosi päätteeksi. Heiton tuloksella 11 tai enemmän katoat nykyiseltä maailmatasolta eetteriin (jos olet valmiiksi jo eetterissä loitsiessasi vilahduksen, loitsiminen epäonnistuu automaattisesti ja loitsuvaraus menee hukkaan).
+
+Seuraavan vuorosi alussa tai viimeistään loitsun keston kuluttua loppuun palaat lähimpään tyhjään tilaan, joka on korkeintaan neljän metrin päässä ja jonka voit nähdä sijainnista, josta katosit eetteriin. Useamman tilan ollessa vapaana samalla etäisyydellä valitaan niistä se, johon palaat satunnaisesti. Voit aina päättää loitsun käyttämällä toiminnon.
+ 
+Kun olet eetterissä, näet ja kuulet maailmatasolle, josta sinne siirryit. Kaikki näyttäytyy harmaan sävyissä ja et voi nähdä 24 metriä pidemmälle. Sinuun vaikuttavat vain olennot, jotka ovat myös eetterissä. Olennot, jotka eivät ole eetterissä, eivät voi nähdä sinua, ellei niillä ole jotain erikseen mainittua kykyä, joka sen sallii, kuten tosinäkö.
+
+----
+
+Ylätaso [Kolmannen piirin loitsut](3_piirin_loitsut.md)
+
+Edellinen [Vetten päällä kävely](Vetten_päällä_kävely.md)
+


### PR DESCRIPTION
Kolmannen piirin loitsukuvaukset Pelaajan kirjan ensimmäisen painoksen tekstin mukaisesti.

Kysymys liittyen **Tulipallo**-loitsuun: onko räjähdyksen koko oikein? Viidennen laitoksen SRD:n mukaan pallon koko on

> Each creature in a 20-foot radius sphere centered on that point must make a Dexterity saving throw.

eli säde, joka on 20 jalkaa. Ymmärsin, että L&L:ssä 5 jalkaa on "pyöristetty ylöspäin" kahteen metriin, joten pitäisikö **Tulipallon** kuvaus olla

> Pallon muotoinen räjähdys ulottuu ***8 metrin*** päähän osumakohdasta.
