### PR TITLE
Fix: Pikkutavara linkki sisällysluettelossa

### DIFF
--- a/Sisällysluettelo.md
+++ b/Sisällysluettelo.md
@@ -18,7 +18,7 @@ Varusteet
 * [Kulut](Varusteet/Kulut)
 * [Ruoat, juoma ja majoitus](Varusteet/Ruoka_ja_juoma)
 * [Palvelut](Varusteet/Palvelut)
-* [Pikkutavarat](Varusteet/Pikkutavarat)
+* [Pikkutavara](Varusteet/Pikkutavara)
 
 Loitsut
 * [0. piirin taikakonstit](Loitsut/0_piirin_taikakonstit) 


### PR DESCRIPTION
Huomasin, että sisällysluettelon linkki osoittaa monikkomuotoon: 
https://www.myrrys.com/LnL-SRD/Varusteet/Pikkutavarat

Mutta itse tiedosto on yksikössä:
https://www.myrrys.com/LnL-SRD/Varusteet/Pikkutavara

Tässä pikkufixi asiaan liittyen.