### PR TITLE
Lisää title- ja description-frontmatter SRD-dokumentteihin

### DIFF
--- a/Hahmonluonti/Vaiheet.md
+++ b/Hahmonluonti/Vaiheet.md
@@ -1,3 +1,8 @@
+---
+title: "Hahmonluonnin vaiheet"
+description: "Hahmonluonnin vaiheet käy läpi koko prosessin lajin, taustan ja hahmoluokan valinnasta hahmolomakkeen täyttämiseen asti."
+---
+
 # Hahmonluonnin vaiheet
 
 Tässä osiossa opastetaan vaihe vaiheelta, kuinka hahmo luodaan.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,8 @@
+---
+title: "Creative Commons Attribution 4.0 International"
+description: "Creative Commons Attribution 4.0 -lisenssin ehdot, jotka määrittävät kuinka L&L SRD -sisältöä saa käyttää, muokata ja jakaa edelleen."
+---
+
 # Creative Commons Attribution 4.0 International
 
 Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.

--- a/Loitsut/0.piirin_taikakonstit.md
+++ b/Loitsut/0.piirin_taikakonstit.md
@@ -1,3 +1,8 @@
+---
+title: "Taikakonstit"
+description: "Taikakonstit listaa kaikki ensimmäisen piirin alapuoliset loitsut druidintaidosta velhonnäytökseen aakkosjärjestyksessä."
+---
+
 ## Taikakonstit
 
 D-V druidintaidosta vähäiseen illuusioon.

--- a/Loitsut/1_piirin_loitsut.md
+++ b/Loitsut/1_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Ensimmäisen piirin loitsut"
+description: "Ensimmäisen piirin loitsut kokoaa yhteen kaikki tason yksi loitsut apulaishengen kutsumisesta väripurskeeseen aakkosjärjestyksessä."
+---
+
 ## Ensimmäisen piirin loitsut
 
 A-V apulaishengen kutsumisesta väripurskeeseen.

--- a/Loitsut/2_piirin_loitsut.md
+++ b/Loitsut/2_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Toisen piirin loitsut"
+description: "Toisen piirin loitsut listaa kaikki tason kaksi loitsut aaveratsusta voimapalautukseen, kuten levitaatio, näkymättömyys ja liekkikuula."
+---
+
 ## Toisen piirin loitsut
 
 A-V Aaveratsusta voimapalautukseen.

--- a/Loitsut/3_piirin_loitsut.md
+++ b/Loitsut/3_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Kolmannen piirin loitsut"
+description: "Kolmannen piirin loitsut esittelee tason kolme loitsuvalikoiman ajatustenvaihdosta vilahdukseen, mukana esimerkiksi tulipallo ja lento."
+---
+
 ## Kolmannen piirin loitsut
 
 A-V ajatustenvaihdosta vilahdukseen.

--- a/Loitsut/4_piirin_loitsut.md
+++ b/Loitsut/4_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Neljännen piirin loitsut"
+description: "Neljännen piirin loitsut kokoaa tason neljä loitsut aavetappajasta villipetojen hallintaan, kuten muodonvaihdos ja tulikilpi."
+---
+
 ## Neljännen piirin loitsut
 
 A-V Aavetappajasta villipetojen hallintaan.

--- a/Loitsut/5_piirin_loitsut.md
+++ b/Loitsut/5_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Viidennen piirin loitsut"
+description: "Viidennen piirin loitsut listaa tason viisi loitsuvalikoiman elementaalin kutsumisesta ylimaalliseen yhteyteen aakkosjärjestyksessä."
+---
+
 ## Viidennen piirin loitsut
 
 E-Y elementaalin kutsumisesta ylimaalliseen yhteyteen.

--- a/Loitsut/6_piirin_loitsut.md
+++ b/Loitsut/6_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Kuudennen piirin loitsut"
+description: "Kuudennen piirin loitsut esittelee tason kuusi loitsut ehdosta ylimaalliseen liittolaiseen, kuten ketjusalama ja parantaminen."
+---
+
 ## Kuudennen piirin loitsut
 
 E-Y ehdosta ylimaalliseen liittolaiseen.

--- a/Loitsut/7_piirin_loitsut.md
+++ b/Loitsut/7_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Seitsemännen piirin loitsut"
+description: "Seitsemännen piirin loitsut kokoaa tason seitsemän loitsuvalikoiman arkkimaagin kartanosta vähäisempään henkiinherätykseen."
+---
+
 ## Seitsemännen piirin loitsut
 
 A-V arkkimaagin kartanosta vähäisempään henkiinherätykseen.

--- a/Loitsut/8_piirin_loitsut.md
+++ b/Loitsut/8_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Kahdeksannen piirin loitsut"
+description: "Kahdeksannen piirin loitsut listaa tason kahdeksan loitsut antimaagisesta alueesta vähämielisyyteen, kuten maanjäristys ja kloonaus."
+---
+
 ## Kahdeksannen piirin loitsut
 
 A-V antimaagisesta alueesta vähämielisyyteen.

--- a/Loitsut/9_piirin_loitsut.md
+++ b/Loitsut/9_piirin_loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Yhdeksännen piirin loitsut"
+description: "Yhdeksännen piirin loitsut esittelee pelin korkeimman tason loitsuvalikoiman ajan pysäytyksestä voimalliseen parannukseen."
+---
+
 ## Yhdeksännen piirin loitsut
 
 A-V ajan pysäytyksestä voimalliseen parannukseen.

--- a/Loitsut/Aaveratsu.md
+++ b/Loitsut/Aaveratsu.md
@@ -1,3 +1,8 @@
+---
+title: "Aaveratsu"
+description: "Aaveratsu on 2-piirin kutsumisloitsu, jolla loihditaan pitkäaikainen keiju-, piru- tai taivaallinen ratsu palvelemaan loitsijaa."
+---
+
 ### Aaveratsu
 
 *2-piirin kutsuminen*

--- a/Loitsut/Aavetappaja.md
+++ b/Loitsut/Aavetappaja.md
@@ -1,3 +1,8 @@
+---
+title: "Aavetappaja"
+description: "Aavetappaja on 4-piirin illuusioloitsu, joka kauhistuttaa kohteen ja aiheuttaa 4n10 hengenvahinkoa toistuvilla viisauspelastusheitoilla."
+---
+
 ### Aavetappaja
 
 *4-piirin illuusio*

--- a/Loitsut/Ajan_pysäytys.md
+++ b/Loitsut/Ajan_pysäytys.md
@@ -1,3 +1,8 @@
+---
+title: "Ajan pysäytys"
+description: "Ajan pysäytys on 9-piirin muovaamisloitsu, joka pysäyttää ajan muilta hetkeksi ja antaa loitsijalle useita peräkkäisiä vuoroja."
+---
+
 ### Ajan pysäytys
 
 *9-piirin muovaaminen*

--- a/Loitsut/Ajattelun_löytäminen.md
+++ b/Loitsut/Ajattelun_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Ajattelun löytäminen"
+description: "Ajattelun löytäminen on 2-piirin ennustamisloitsu, joka antaa lukea 12 metrin säteellä olevan älyllisen olennon ajatuksia."
+---
+
 ### Ajattelun löytäminen
 
 *2-piirin ennustaminen*

--- a/Loitsut/Ajatustenvaihto.md
+++ b/Loitsut/Ajatustenvaihto.md
@@ -1,3 +1,8 @@
+---
+title: "Ajatustenvaihto"
+description: "Ajatustenvaihto on 3-piirin luomisloitsu, jolla lähetetään ja vastaanotetaan alle 25 sanan mittainen telepaattinen viesti tuttavalle."
+---
+
 ### Ajatustenvaihto
 
 *3-piirin luominen* 

--- a/Loitsut/Ansojen_löytäminen.md
+++ b/Loitsut/Ansojen_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Ansojen löytäminen"
+description: "Ansojen löytäminen on 2-piirin ennustamisloitsu, jolla aistitaan näköpiirissä olevien ansojen ja ansamaisten loitsujen läsnäolo."
+---
+
 ### Ansojen löytäminen
 
 *2-piirin ennustaminen*

--- a/Loitsut/Antimaaginen_alue.md
+++ b/Loitsut/Antimaaginen_alue.md
@@ -1,3 +1,8 @@
+---
+title: "Antimaaginen alue"
+description: "Antimaaginen alue on 8-piirin suojelusloitsu, joka luo loitsijan ympärille kuplan, jossa taikuus ei toimi ja taikaesineet mitätöityvät."
+---
+
 ### Antimaaginen alue
 
 *8-piirin suojelus*

--- a/Loitsut/Antipatia_Sympatia.md
+++ b/Loitsut/Antipatia_Sympatia.md
@@ -1,3 +1,8 @@
+---
+title: "Antipatia / Sympatia"
+description: "Antipatia / Sympatia on 8-piirin lumoamisloitsu, joka saa valitun olentotyypin karttamaan tai hakeutumaan kohteen luo kymmenen päivän ajan."
+---
+
 ### Antipatia / Sympatia
 
 *8-piirin lumoaminen*

--- a/Loitsut/Apu.md
+++ b/Loitsut/Apu.md
@@ -1,3 +1,8 @@
+---
+title: "Apu"
+description: "Apu on 2-piirin suojelusloitsu, joka nostaa enintään kolmen liittolaisen nykyisiä ja maksimiosumapisteitä viidellä kahdeksaksi tunniksi."
+---
+
 ### Apu
 
 *2-piirin suojelus*

--- a/Loitsut/Apulaishengen_kutsuminen.md
+++ b/Loitsut/Apulaishengen_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Apulaishengen kutsuminen"
+description: "Apulaishengen kutsuminen on 1-piirin kutsumisrituaali, joka antaa loitsijalle uskollisen eläinmuotoisen apulaishengen kumppaniksi."
+---
+
 ### Apulaishengen kutsuminen
 
 *1-piirin kutsuminen (rituaali)*

--- a/Loitsut/Arkkimaagin_kartano.md
+++ b/Loitsut/Arkkimaagin_kartano.md
@@ -1,3 +1,8 @@
+---
+title: "Arkkimaagin kartano"
+description: "Arkkimaagin kartano on 7-piirin kutsumisloitsu, joka avaa 24 tunniksi portin varjomaailmassa sijaitsevaan ylelliseen majapaikkaan."
+---
+
 ### Arkkimaagin kartano
 
 *7-piirin kutsuminen*

--- a/Loitsut/Astraaliprojektio.md
+++ b/Loitsut/Astraaliprojektio.md
@@ -1,3 +1,8 @@
+---
+title: "Astraaliprojektio"
+description: "Astraaliprojektio on 9-piirin kuolontaikuusloitsu, jolla loitsija ja seuralaiset lähettävät astraalikehonsa matkalle astraalitasolle."
+---
+
 ### Astraaliprojektio
 
 *9-piirin kuolontaikuus*

--- a/Loitsut/Aurinkopurske.md
+++ b/Loitsut/Aurinkopurske.md
@@ -1,3 +1,8 @@
+---
+title: "Aurinkopurske"
+description: "Aurinkopurske on 8-piirin luomisloitsu, joka räjäyttää 24 metrin säteelle hohkavaa auringonvaloa ja aiheuttaa 12n6 vahinkoa sekä sokaisua."
+---
+
 ### Aurinkopurske
 
 *8-piirin luominen*

--- a/Loitsut/Druidintaito.md
+++ b/Loitsut/Druidintaito.md
@@ -1,3 +1,8 @@
+---
+title: "Druidintaito"
+description: "Druidintaito on muovaamiseen kuuluva taikakonsti, jolla luodaan pieniä luonnonläheisiä vaikutuksia, kuten säänennustus tai kukan puhkeaminen."
+---
+
 ### Druidintaito
 
 *Taikakonsti, muovaaminen* 

--- a/Loitsut/Eetterimuoto.md
+++ b/Loitsut/Eetterimuoto.md
@@ -1,3 +1,8 @@
+---
+title: "Eetterimuoto"
+description: "Eetterimuoto on 7-piirin muovaamisloitsu, joka siirtää loitsijan rajaeetteriin, jolloin hän voi liikkua vapaasti seinien ja esteiden läpi."
+---
+
 ### Eetterimuoto
 
 *7-piirin muovaaminen*

--- a/Loitsut/Ehdotus.md
+++ b/Loitsut/Ehdotus.md
@@ -1,3 +1,8 @@
+---
+title: "Ehdotus"
+description: "Ehdotus on 2-piirin lumoamisloitsu, joka saa kohteen suorittamaan lauseen tai kahden mittaisen tehtävän epäonnistuneen pelastusheiton jälkeen."
+---
+
 ### Ehdotus
 
 *2-piirin lumoaminen*

--- a/Loitsut/Ehto.md
+++ b/Loitsut/Ehto.md
@@ -1,3 +1,8 @@
+---
+title: "Ehto"
+description: "Ehto on 6-piirin luomisloitsu, jolla toinen loitsu ladataan aktivoitumaan vasta loitsijan määrittelemän ehdon täyttyessä kymmenen päivän ajan."
+---
+
 ### Ehto
 
 *6-piirin luominen*

--- a/Loitsut/Elementaalin_kutsuminen.md
+++ b/Loitsut/Elementaalin_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Elementaalin kutsuminen"
+description: "Elementaalin kutsuminen on 5-piirin kutsumisloitsu, joka manaa ilman, maan, tulen tai veden elementaalin palvelemaan loitsijaa tunnin ajan."
+---
+
 ### Elementaalin kutsuminen
 
 *5-piirin kutsuminen*

--- a/Loitsut/Elvytys.md
+++ b/Loitsut/Elvytys.md
@@ -1,3 +1,8 @@
+---
+title: "Elvytys"
+description: "Elvytys on 3-piirin kuolontaikuusloitsu, jolla palautetaan henkiin minuutin sisällä kuollut olento yhden osumapisteen turvin."
+---
+
 ### Elvytys
 
 *3-piirin kuolontaikuus* 

--- a/Loitsut/Eläimille_puhuminen.md
+++ b/Loitsut/Eläimille_puhuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Eläimille puhuminen"
+description: "Eläimille puhuminen on 1-piirin ennustamisloitsu, joka antaa loitsijan ymmärtää eläimiä ja saada niiltä tietoa lähialueen tapahtumista."
+---
+
 ### Eläimille puhuminen
 
 *1-piirin ennustaminen*

--- a/Loitsut/Eläinlähetti.md
+++ b/Loitsut/Eläinlähetti.md
@@ -1,3 +1,8 @@
+---
+title: "Eläinlähetti"
+description: "Eläinlähetti on 2-piirin lumoamisrituaali, jolla pieni eläin lähetetään kuljettamaan alle 25 sanan viesti tunnistetulle vastaanottajalle."
+---
+
 ### Eläinlähetti
 
 *2-piirin lumoaminen (rituaali)*

--- a/Loitsut/Eläinmuoto.md
+++ b/Loitsut/Eläinmuoto.md
@@ -1,3 +1,8 @@
+---
+title: "Eläinmuoto"
+description: "Eläinmuoto on 8-piirin muovaamisloitsu, joka muuttaa vapaaehtoisia olentoja suurikokoisiksi eläimiksi enintään vuorokauden ajaksi."
+---
+
 ### Eläinmuoto
 
 *8-piirin muovaaminen*

--- a/Loitsut/Eläinten_kutsuminen.md
+++ b/Loitsut/Eläinten_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Eläinten kutsuminen"
+description: "Eläinten kutsuminen on 3-piirin kutsumisloitsu, joka manaa esiin eläinhahmoisia keijunhenkiä taistelemaan loitsijan rinnalla tunnin ajan."
+---
+
 ### Eläinten kutsuminen
 
 *3-piirin kutsuminen* 

--- a/Loitsut/Eläinten_tai_kasvien_löytäminen.md
+++ b/Loitsut/Eläinten_tai_kasvien_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Eläinten tai kasvien löytäminen"
+description: "Eläinten tai kasvien löytäminen on 2-piirin ennustamisrituaali, jolla paikannetaan lähin haluttu eläin- tai kasvilaji kahdeksan kilometrin säteellä."
+---
+
 ### Eläinten tai kasvien löytäminen
 
 *2-piirin ennustaminen (rituaali)*

--- a/Loitsut/Eläinystävä.md
+++ b/Loitsut/Eläinystävä.md
@@ -1,3 +1,8 @@
+---
+title: "Eläinystävä"
+description: "Eläinystävä on 1-piirin lumoamisloitsu, joka vakuuttaa kohteena olevan eläimen loitsijan hyvistä aikomuksista ja lumoaa sen vuorokaudeksi."
+---
+
 ### Eläinystävä
 
 *1-piirin lumoaminen*

--- a/Loitsut/Elämänlanka.md
+++ b/Loitsut/Elämänlanka.md
@@ -1,3 +1,8 @@
+---
+title: "Elämänlanka"
+description: "Elämänlanka on 4-piirin suojelusloitsu, joka estää kohteen kuoleman ensimmäisellä nollaan laskevalla osumapistevahingolla kahdeksan tunnin ajan."
+---
+
 ### Elämänlanka
 
 *4-piirin suojelus*

--- a/Loitsut/Ennusmerkit.md
+++ b/Loitsut/Ennusmerkit.md
@@ -1,3 +1,8 @@
+---
+title: "Ennusmerkit"
+description: "Ennusmerkit on 2-piirin ennustamisrituaali, jolla heitetään ennustustikkuja ja saadaan yliluonnollinen enne lähitulevaisuuden toimista."
+---
+
 ### Ennusmerkit
 
 *2-piirin ennustaminen (rituaali)*

--- a/Loitsut/Ennustaminen.md
+++ b/Loitsut/Ennustaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Ennustaminen"
+description: "Ennustaminen on 4-piirin ennustamisrituaali, joka antaa yhteyden jumalalliseen olentoon ja vastauksen yhteen kysymykseen tulevasta viikosta."
+---
+
 ### Ennustaminen
 
 *4-piirin ennustaminen (rituaali)*

--- a/Loitsut/Epäkuolleen_luominen.md
+++ b/Loitsut/Epäkuolleen_luominen.md
@@ -1,3 +1,8 @@
+---
+title: "Epäkuolleen luominen"
+description: "Epäkuolleen luominen on 6-piirin kuolontaikuusloitsu, joka muuttaa yöllä enintään kolme ruumista loitsijan komentamiksi kaamioiksi."
+---
+
 ### Epäkuolleen luominen
 
 *6-piirin kuolontaikuus*

--- a/Loitsut/Epäkuollut_palvelija.md
+++ b/Loitsut/Epäkuollut_palvelija.md
@@ -1,3 +1,8 @@
+---
+title: "Epäkuollut palvelija"
+description: "Epäkuollut palvelija on 3-piirin kuolontaikuusloitsu, joka herättää luukasan tai ruumiin loitsijaa palvelevaksi luurangoksi tai zombiksi."
+---
+
 ### Epäkuollut palvelija
 
 *3-piirin kuolontaikuus* 

--- a/Loitsut/Esineen_herättäminen.md
+++ b/Loitsut/Esineen_herättäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Esineen herättäminen"
+description: "Esineen herättäminen on 5-piirin kutsumisloitsu, joka herättää henkiin enintään kymmenen ei-maagista esinettä komentamaan totteleviksi olennoiksi."
+---
+
 ### Esineen herättäminen
 
 *5-piirin kutsuminen*

--- a/Loitsut/Esineen_löytäminen.md
+++ b/Loitsut/Esineen_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Esineen löytäminen"
+description: "Esineen löytäminen on 2-piirin ennustamisloitsu, jolla aistitaan tutun tai tietyntyyppisen esineen suunta 300 metrin säteellä."
+---
+
 ### Esineen löytäminen
 
 *2-piirin ennustaminen*

--- a/Loitsut/Etäkatselu.md
+++ b/Loitsut/Etäkatselu.md
@@ -1,3 +1,8 @@
+---
+title: "Etäkatselu"
+description: "Etäkatselu on 5-piirin ennustamisloitsu, joka avaa näkymän ja kuulon tuttuun kohteeseen samalla maailmatasolla kristallipallon avulla."
+---
+
 ### Etäkatselu
 
 *5-piirin ennustaminen*

--- a/Loitsut/Haavoittaminen.md
+++ b/Loitsut/Haavoittaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Haavoittaminen"
+description: "Haavoittaminen on 1-piirin kuolontaikuusloitsu, joka tekee lähitaisteluhyökkäyksen ja aiheuttaa osuessaan 3n10 kuolonvahinkoa kohteeseen."
+---
+
 ### Haavoittaminen
 
 *1-piirin kuolontaikuus*

--- a/Loitsut/Haavojen_parannus.md
+++ b/Loitsut/Haavojen_parannus.md
@@ -1,3 +1,8 @@
+---
+title: "Haavojen parannus"
+description: "Haavojen parannus on 1-piirin luomisloitsu, joka palauttaa kosketuksella 1n8 plus loitsimisominaisuuden verran osumapisteitä kohteelle."
+---
+
 ### Haavojen parannus
 
 *1-piirin luominen*

--- a/Loitsut/Happonuoli.md
+++ b/Loitsut/Happonuoli.md
@@ -1,3 +1,8 @@
+---
+title: "Happonuoli"
+description: "Happonuoli on 2-piirin luomisloitsu, joka ampuu vihreän happonuolen ja aiheuttaa 4n4 välitöntä ja 2n4 viivästettyä happovahinkoa."
+---
+
 ### Happonuoli
 
 *2-piirin luominen*

--- a/Loitsut/Happoroiske.md
+++ b/Loitsut/Happoroiske.md
@@ -1,3 +1,8 @@
+---
+title: "Happoroiske"
+description: "Happoroiske on kutsumiseen kuuluva taikakonsti, joka heittää happosuihkun ja aiheuttaa 1n6 happovahinkoa epäonnistuneella ketteryysheitolla."
+---
+
 ### Happoroiske
 
 *Taikakonsti, kutsuminen*

--- a/Loitsut/Heikentävä_säde.md
+++ b/Loitsut/Heikentävä_säde.md
@@ -1,3 +1,8 @@
+---
+title: "Heikentävä säde"
+description: "Heikentävä säde on 2-piirin kuolontaikuusloitsu, joka puolittaa kohteen voimakkuuteen pohjautuvien lähihyökkäysten vahingon minuutin ajaksi."
+---
+
 ### Heikentävä säde
 
 *2-piirin kuolontaikuus*

--- a/Loitsut/Henkiherruus.md
+++ b/Loitsut/Henkiherruus.md
@@ -1,3 +1,8 @@
+---
+title: "Henkiherruus"
+description: "Henkiherruus on 5-piirin suojelusloitsu, joka pyrkii sitomaan taivaallisen olennon, elementaalin, keijun tai pirun vuorokauden palvelukseen."
+---
+
 ### Henkiherruus
 
 *5-piirin suojelus*

--- a/Loitsut/Henkiinherätys.md
+++ b/Loitsut/Henkiinherätys.md
@@ -1,3 +1,8 @@
+---
+title: "Henkiinherätys"
+description: "Henkiinherätys on 9-piirin kuolontaikuusloitsu, jolla palautetaan täysissä osumapisteissä henkiin enintään 200 vuotta kuolleena ollut olento."
+---
+
 ### Henkiinherätys
 
 *9-piirin kuolontaikuus*

--- a/Loitsut/Herättäminen.md
+++ b/Loitsut/Herättäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Herättäminen"
+description: "Herättäminen on 5-piirin muovaamisloitsu, joka nostaa kasvin tai eläimen älykkyyden kymmeneen ja antaa sille liikkumiskyvyn ja ihmisen aistit."
+---
+
 ### Herättäminen
 
 *5-piirin muovaaminen*

--- a/Loitsut/Hidastus.md
+++ b/Loitsut/Hidastus.md
@@ -1,3 +1,8 @@
+---
+title: "Hidastus"
+description: "Hidastus on 3-piirin muovaamisloitsu, joka puolittaa enintään kuuden kohteen kulkunopeuden ja antaa haitan puolustukseen ja pelastusheittoihin."
+---
+
 ### Hidastus
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Hiljaisuus.md
+++ b/Loitsut/Hiljaisuus.md
@@ -1,3 +1,8 @@
+---
+title: "Hiljaisuus"
+description: "Hiljaisuus on 2-piirin illuusiorituaali, joka luo 8 metrin säteisen alueen, jossa ei synny ääniä ja taikasanoja vaativat loitsut estyvät."
+---
+
 ### Hiljaisuus
 
 *2-piirin illuusio (rituaali)*

--- a/Loitsut/Hirviön_alistaminen.md
+++ b/Loitsut/Hirviön_alistaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Hirviön alistaminen"
+description: "Hirviön alistaminen on 8-piirin lumoamisloitsu, joka lumoaa minkä tahansa näköpiirissä olevan olennon ja antaa siihen telepaattisen komentolinkin."
+---
+
 ### Hirviön alistaminen
 
 *8-piirin lumoaminen*

--- a/Loitsut/Hirviön_pysäyttäminen.md
+++ b/Loitsut/Hirviön_pysäyttäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Hirviön pysäyttäminen"
+description: "Hirviön pysäyttäminen on 5-piirin lumoamisloitsu, joka halvaannuttaa epäonnistuneella viisauspelastusheitolla yhden kohteen minuutin ajaksi."
+---
+
 ### Hirviön pysäyttäminen
 
 *5-piirin lumoaminen*

--- a/Loitsut/Hohkaava_isku.md
+++ b/Loitsut/Hohkaava_isku.md
@@ -1,3 +1,8 @@
+---
+title: "Hohkaava isku"
+description: "Hohkaava isku on 2-piirin luomisloitsu, joka lisää seuraavaan osumaan 2n6 hohkavahinkoa ja paljastaa mahdollisen näkymättömän kohteen."
+---
+
 ### Hohkaava isku
 
 *2-piirin luominen*

--- a/Loitsut/Hornankosto.md
+++ b/Loitsut/Hornankosto.md
@@ -1,3 +1,8 @@
+---
+title: "Hornankosto"
+description: "Hornankosto on 1-piirin luomisreaktio, joka kostaa vahingoittajalle heti ja aiheuttaa 2n10 tulivahinkoa epäonnistuneella ketteryysheitolla."
+---
+
 ### Hornankosto
 
 *1-piirin luominen*

--- a/Loitsut/Houkutuslintu.md
+++ b/Loitsut/Houkutuslintu.md
@@ -1,3 +1,8 @@
+---
+title: "Houkutuslintu"
+description: "Houkutuslintu on 5-piirin illuusioloitsu, joka luo loitsijasta liikkuvan illuusiokopion ja tekee loitsijasta itsestään samalla näkymättömän."
+---
+
 ### Houkutuslintu
 
 *5-piirin illuusio*

--- a/Loitsut/Huomaamattomuus.md
+++ b/Loitsut/Huomaamattomuus.md
@@ -1,3 +1,8 @@
+---
+title: "Huomaamattomuus"
+description: "Huomaamattomuus on 3-piirin suojelusloitsu, joka kätkee kohteen kahdeksaksi tunniksi kaikelta ennustamisen koulukunnan taikuudelta ja etäkatselulta."
+---
+
 ### Huomaamattomuus
 
 *3-piirin suojelus* 

--- a/Loitsut/Hypnoottinen_kuvio.md
+++ b/Loitsut/Hypnoottinen_kuvio.md
@@ -1,3 +1,8 @@
+---
+title: "Hypnoottinen kuvio"
+description: "Hypnoottinen kuvio on 3-piirin illuusioloitsu, joka lumoaa ja tekee toimintakyvyttömäksi kaikki kuvion näkevät olennot minuutin ajaksi."
+---
+
 ### Hypnoottinen kuvio
 
 *3-piirin illuusio* 

--- a/Loitsut/Hyppy.md
+++ b/Loitsut/Hyppy.md
@@ -1,3 +1,8 @@
+---
+title: "Hyppy"
+description: "Hyppy on 1-piirin muovaamisloitsu, jolla koskettamasi olennon hyppäämä matka kolminkertaistuu yhden minuutin ajaksi."
+---
+
 ### Hyppy
 
 *1-piirin muovaaminen*

--- a/Loitsut/Hyvän_ja_pahan_hajottaminen.md
+++ b/Loitsut/Hyvän_ja_pahan_hajottaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Hyvän ja pahan hajottaminen"
+description: "Hyvän ja pahan hajottaminen on 5-piirin suojelusloitsu, joka antaa haitan taivaallisten, epäkuolleiden ja keijujen hyökkäyksille loitsijaa vastaan."
+---
+
 ### Hyvän ja pahan hajottaminen
 
 *5-piirin suojelus*

--- a/Loitsut/Hyvän_ja_pahan_löytäminen.md
+++ b/Loitsut/Hyvän_ja_pahan_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Hyvän tai pahan löytäminen"
+description: "Hyvän tai pahan löytäminen on 1-piirin ennustamisloitsu, jolla aistitaan epäkuolleiden, keijujen, pirujen ja taivaallisten sijainti läheltä."
+---
+
 ### Hyvän tai pahan löytäminen
 
 *1-piirin ennustaminen*

--- a/Loitsut/Hyytävä_purkaus.md
+++ b/Loitsut/Hyytävä_purkaus.md
@@ -1,3 +1,8 @@
+---
+title: "Hyytävä purkaus"
+description: "Hyytävä purkaus on 5-piirin luomisloitsu, joka purkaa käsistä 24 metrin kylmäkartion ja aiheuttaa 8n8 kylmävahinkoa sitkeyspelastusheitolla puolitettuna."
+---
+
 ### Hyytävä purkaus
 
 *5-piirin luominen*

--- a/Loitsut/Hyönteisvitsaus.md
+++ b/Loitsut/Hyönteisvitsaus.md
@@ -1,3 +1,8 @@
+---
+title: "Hyönteisvitsaus"
+description: "Hyönteisvitsaus on 5-piirin kutsumisloitsu, joka täyttää alueen pistävillä heinäsirkoilla ja aiheuttaa 4n10 pistovahinkoa sitkeysheitolla puolitettuna."
+---
+
 ### Hyönteisvitsaus
 
 *5-piirin kutsuminen*

--- a/Loitsut/Hälytys.md
+++ b/Loitsut/Hälytys.md
@@ -1,3 +1,8 @@
+---
+title: "Hälytys"
+description: "Hälytys on 1-piirin suojelusrituaali, joka asettaa kahdeksan tunniksi hälytyksen ovelle tai alueelle ja ilmoittaa ei-toivotuista vierailijoista."
+---
+
 ### Hälytys
 
 *1-piirin suojelus (rituaali)*

--- a/Loitsut/Hämmennys.md
+++ b/Loitsut/Hämmennys.md
@@ -1,3 +1,8 @@
+---
+title: "Hämmennys"
+description: "Hämmennys on 4-piirin lumoamisloitsu, joka väännää neljän metrin pallossa olevien mielet solmuun ja arpoo satunnaisen käytöksen jokaiselle vuorolle."
+---
+
 ### Hämmennys
 
 *4-piirin lumoaminen*

--- a/Loitsut/Hämähäkkikiipeily.md
+++ b/Loitsut/Hämähäkkikiipeily.md
@@ -1,3 +1,8 @@
+---
+title: "Hämähäkkikiipeily"
+description: "Hämähäkkikiipeily on 2-piirin muovaamisloitsu, joka antaa kohteen liikkua seinillä ja katossa tavanomaisella nopeudella tunnin ajan."
+---
+
 ### Hämähäkkikiipeily
 
 *2-piirin muovaaminen*

--- a/Loitsut/Höyhenpudotus.md
+++ b/Loitsut/Höyhenpudotus.md
@@ -1,3 +1,8 @@
+---
+title: "Höyhenpudotus"
+description: "Höyhenpudotus on 1-piirin muovaamisreaktio, joka hidastaa enintään viiden putoavan olennon laskeutumisen ja estää putoamisvahingon."
+---
+
 ### Höyhenpudotus
 
 *1-piirin muovaaminen*

--- a/Loitsut/Jemma.md
+++ b/Loitsut/Jemma.md
@@ -1,3 +1,8 @@
+---
+title: "Jemma"
+description: "Jemma on 4-piirin kutsumisloitsu, joka kätkee kirstun sisältöineen eetteriin ja mahdollistaa sen kutsumisen esiin myöhemmin toiminnolla."
+---
+
 ### Jemma
 
 *4-piirin kutsuminen*

--- a/Loitsut/Johdatus.md
+++ b/Loitsut/Johdatus.md
@@ -1,3 +1,8 @@
+---
+title: "Johdatus"
+description: "Johdatus on 5-piirin ennustamisrituaali, joka avaa yhteyden palvottuun jumaluuteen ja antaa vastauksen enintään kolmeen kyllä-ei-kysymykseen."
+---
+
 ### Johdatus
 
 *5-piirin ennustaminen (rituaali)*

--- a/Loitsut/Joukkohurmos.md
+++ b/Loitsut/Joukkohurmos.md
@@ -1,3 +1,8 @@
+---
+title: "Joukkohurmos"
+description: "Joukkohurmos on 6-piirin lumoamisloitsu, joka taivuttelee enintään 12 olentoa suorittamaan ehdotetun lauseen tai kahden mittaisen tehtävän."
+---
+
 ### Joukkohurmos
 
 *6-piirin lumoaminen*

--- a/Loitsut/Joukkoparannus.md
+++ b/Loitsut/Joukkoparannus.md
@@ -1,3 +1,8 @@
+---
+title: "Joukkoparannus"
+description: "Joukkoparannus on 5-piirin luomisloitsu, joka parantaa enintään kuutta kohdetta 3n8 plus loitsimisominaisuuden verran osumapisteitä."
+---
+
 ### Joukkoparannus
 
 *5-piirin luominen*

--- a/Loitsut/Julma_iva.md
+++ b/Loitsut/Julma_iva.md
@@ -1,3 +1,8 @@
+---
+title: "Julma iva"
+description: "Julma iva on lumoamiseen kuuluva taikakonsti, joka sadattelee kohdetta ja aiheuttaa 1n4 hengenvahinkoa sekä haitan seuraavaan hyökkäysheittoon."
+---
+
 ### Julma iva
 
 *Taikakonsti, lumoaminen*

--- a/Loitsut/Jumalallinen_mahtisana.md
+++ b/Loitsut/Jumalallinen_mahtisana.md
@@ -1,3 +1,8 @@
+---
+title: "Jumalallinen mahtisana"
+description: "Jumalallinen mahtisana on 7-piirin kutsumisloitsu, joka rankaisee epäonnistuneella karismaheitolla kohteita niiden jäljellä olevien osumapisteiden mukaan."
+---
+
 ### Jumalallinen mahtisana
 
 *7-piirin kutsuminen*

--- a/Loitsut/Jäljittä_kulkeminen.md
+++ b/Loitsut/Jäljittä_kulkeminen.md
@@ -1,3 +1,8 @@
+---
+title: "Jäljittä kulkeminen"
+description: "Jäljittä kulkeminen on 2-piirin suojelusloitsu, joka antaa lähialueen olennoille edun hiipimisessä ja estää jälkien jättämisen tunnin ajan."
+---
+
 ### Jäljittä kulkeminen
 
 *2-piirin suojelus*

--- a/Loitsut/Jättiläisötökkä.md
+++ b/Loitsut/Jättiläisötökkä.md
@@ -1,3 +1,8 @@
+---
+title: "Jättiläisötökkä"
+description: "Jättiläisötökkä on 4-piirin muovaamisloitsu, joka muuttaa enintään kolme tavallista ötökkää vaarallisiksi jättikokoisiksi versioiksi."
+---
+
 ### Jättiläisötökkä
 
 *4-piirin muovaaminen*

--- a/Loitsut/Jäädytyssäde.md
+++ b/Loitsut/Jäädytyssäde.md
@@ -1,3 +1,8 @@
+---
+title: "Jäädytyssäde"
+description: "Jäädytyssäde on luomiseen kuuluva taikakonsti, joka kohdistaa kylmän valon kohteeseen ja aiheuttaa 1n8 kylmävahinkoa sekä hidastaa nopeutta."
+---
+
 ### Jäädytyssäde
 
 *Taikakonsti, luominen*

--- a/Loitsut/Jäämyrsky.md
+++ b/Loitsut/Jäämyrsky.md
@@ -1,3 +1,8 @@
+---
+title: "Jäämyrsky"
+description: "Jäämyrsky on 4-piirin luomisloitsu, joka saa aikaan raesateen ja aiheuttaa 2n8 murskaus- ja 4n6 kylmävahinkoa ketteryysheitolla puolitettuna."
+---
+
 ### Jäämyrsky
 
 *4-piirin luominen*

--- a/Loitsut/Jäävalli.md
+++ b/Loitsut/Jäävalli.md
@@ -1,3 +1,8 @@
+---
+title: "Jäävalli"
+description: "Jäävalli on 6-piirin luomisloitsu, joka luo jäisen puolipallon, ympyrän tai seinämän kiinteälle alustalle kymmeneksi minuutiksi."
+---
+
 ### Jäävalli
 
 *6-piirin luominen*

--- a/Loitsut/Kaarnaiho.md
+++ b/Loitsut/Kaarnaiho.md
@@ -1,3 +1,8 @@
+---
+title: "Kaarnaiho"
+description: "Kaarnaiho on 2-piirin muovaamisloitsu, joka karkeuttaa kohteen ihon puun kaarnan tavoin ja takaa vähintään 16 puolustusarvon tunnin ajan."
+---
+
 ### Kaarnaiho
 
 *2-piirin muovaaminen*

--- a/Loitsut/Kaasumuoto.md
+++ b/Loitsut/Kaasumuoto.md
@@ -1,3 +1,8 @@
+---
+title: "Kaasumuoto"
+description: "Kaasumuoto on 3-piirin muovaamisloitsu, joka muuttaa vapaaehtoisen olennon sumupilveksi, jolloin tämä voi lentää ja liikkua rakojen läpi."
+---
+
 ### Druidintaito
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Kalmaelo.md
+++ b/Loitsut/Kalmaelo.md
@@ -1,3 +1,8 @@
+---
+title: "Kalmaelo"
+description: "Kalmaelo on 1-piirin kuolontaikuusloitsu, joka antaa loitsijalle 1n4 plus neljä väliaikaista osumapistettä tunnin ajaksi."
+---
+
 ### Kalmaelo
 
 *1-piirin kuolontaikuus*

--- a/Loitsut/Kampitus.md
+++ b/Loitsut/Kampitus.md
@@ -1,3 +1,8 @@
+---
+title: "Kampitus"
+description: "Kampitus on 1-piirin kutsumisloitsu, joka kasvattaa alueelle takertuvia köynnöksiä ja sitoo olennot niihin epäonnistuneella voimakkuusheitolla."
+---
+
 ### Kampitus
 
 *1-piirin kutsuminen*

--- a/Loitsut/Kangastus.md
+++ b/Loitsut/Kangastus.md
@@ -1,3 +1,8 @@
+---
+title: "Kangastus"
+description: "Kangastus on 4-piirin illuusioloitsu, joka peittää enintään 60 metrin alueen näyttämään toiselta maastotyypiltä vuorokauden ajaksi."
+---
+
 ### Kangastus
 
 *4-piirin illuusio*

--- a/Loitsut/Karkottaminen.md
+++ b/Loitsut/Karkottaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Karkottaminen"
+description: "Karkottaminen on 4-piirin suojelusloitsu, joka siirtää epäonnistuneella karismaheitolla kohteen toiselle maailmatasolle minuutin ajaksi."
+---
+
 ### Karkottaminen
 
 *4-piirin suojelus*

--- a/Loitsut/Kasveille_puhuminen.md
+++ b/Loitsut/Kasveille_puhuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kasveille puhuminen"
+description: "Kasveille puhuminen on 3-piirin muovaamisloitsu, joka saa 12 metrin säteellä olevat kasvit kommunikoimaan ja muuttaa maaston kulkukelpoisuutta."
+---
+
 ### Kasveille puhuminen
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Kasvikasvu.md
+++ b/Loitsut/Kasvikasvu.md
@@ -1,3 +1,8 @@
+---
+title: "Kasvikasvu"
+description: "Kasvikasvu on 3-piirin muovaamisloitsu, joka ylikasvattaa alueen kasvillisuutta vaikeaksi maastoksi tai tekee siitä hedelmällisemmän."
+---
+
 ### Kasvikasvu
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Kasviportti.md
+++ b/Loitsut/Kasviportti.md
@@ -1,3 +1,8 @@
+---
+title: "Kasviportti"
+description: "Kasviportti on 6-piirin kutsumisloitsu, joka luo yhteyden kahden suuren kasvin välille ja mahdollistaa kulkemisen niiden läpi kierroksen ajan."
+---
+
 ### Kasviportti
 
 *6-piirin kutsuminen*

--- a/Loitsut/Kato.md
+++ b/Loitsut/Kato.md
@@ -1,3 +1,8 @@
+---
+title: "Kato"
+description: "Kato on 4-piirin kuolontaikuusloitsu, joka imee kohteesta elinvoimaa ja aiheuttaa 8n8 kuolonvahinkoa sitkeyspelastusheitolla puolitettuna."
+---
+
 ### Kato
 
 *4-piirin kuolontaikuus*

--- a/Loitsut/Kaukokatse.md
+++ b/Loitsut/Kaukokatse.md
@@ -1,3 +1,8 @@
+---
+title: "Kaukokatse"
+description: "Kaukokatse on 9-piirin ennustamisloitsu, joka antaa kohteelle kyvyn nähdä lähitulevaisuuteen ja edun kaikkiin heittoihin kahdeksan tunnin ajan."
+---
+
 ### Kaukokatse
 
 *9-piirin ennustaminen*

--- a/Loitsut/Kaukoportti.md
+++ b/Loitsut/Kaukoportti.md
@@ -1,3 +1,8 @@
+---
+title: "Kaukoportti"
+description: "Kaukoportti on 9-piirin kutsumisloitsu, joka avaa portin toiselle maailmatasolle valittuun sijaintiin enintään minuutin ajaksi."
+---
+
 ### Kaukoportti
 
 *9-piirin kutsuminen*

--- a/Loitsut/Kaunopuhe.md
+++ b/Loitsut/Kaunopuhe.md
@@ -1,3 +1,8 @@
+---
+title: "Kaunopuhe"
+description: "Kaunopuhe on 8-piirin muovaamisloitsu, joka korvaa karismaheittojen tuloksen viitosellatoista ja saa puheen kuulostamaan aina totuudelta."
+---
+
 ### Kaunopuhe
 
 *8-piirin muovaaminen*

--- a/Loitsut/Kehonmuutos.md
+++ b/Loitsut/Kehonmuutos.md
@@ -1,3 +1,8 @@
+---
+title: "Kehonmuutos"
+description: "Kehonmuutos on 2-piirin muovaamisloitsu, joka antaa loitsijalle valittavia kehon muutoksia, kuten vedenalaisen sopeutumisen tai ulkonäön muokkauksen."
+---
+
 ### Kehonmuutos
 
 *2-piirin muovaaminen*

--- a/Loitsut/Keijuliekki.md
+++ b/Loitsut/Keijuliekki.md
@@ -1,3 +1,8 @@
+---
+title: "Keijuliekki"
+description: "Keijuliekki on 1-piirin luomisloitsu, joka merkitsee alueen olennot hohtavalla valolla ja antaa etua niitä vastaan tehtyihin hyökkäyksiin."
+---
+
 ### Keijuliekki
 
 *1-piirin luominen*

--- a/Loitsut/Keijun_kutsuminen.md
+++ b/Loitsut/Keijun_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Keijun kutsuminen"
+description: "Keijun kutsuminen on 6-piirin kutsumisloitsu, joka manaa esiin ystävällisen keijuolennon tai keijuhengen taistelemaan loitsijan rinnalla."
+---
+
 ### Keijun kutsuminen
 
 *6-piirin kutsuminen*

--- a/Loitsut/Ketjusalama.md
+++ b/Loitsut/Ketjusalama.md
@@ -1,3 +1,8 @@
+---
+title: "Ketjusalama"
+description: "Ketjusalama on 6-piirin luomisloitsu, joka iskee sähkövasaman neljään kohteeseen ja aiheuttaa 10n8 salamavahinkoa ketteryysheitolla puolitettuna."
+---
+
 ### Ketjusalama
 
 *6-piirin luominen*

--- a/Loitsut/Kiehtova.md
+++ b/Loitsut/Kiehtova.md
@@ -1,3 +1,8 @@
+---
+title: "Kiehtova"
+description: "Kiehtova on 2-piirin lumoamisloitsu, joka lumoaa kuulijat ja antaa heille haitan huomata muita kuin loitsijaa itseään minuutin ajaksi."
+---
+
 ### Kiehtova
 
 *2-piirin lumoaminen*

--- a/Loitsut/Kielillä_puhuminen.md
+++ b/Loitsut/Kielillä_puhuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kielillä puhuminen"
+description: "Kielillä puhuminen on 3-piirin ennustamisloitsu, joka antaa koskettamalleen olennolle kyvyn ymmärtää ja tulla ymmärretyksi kaikilla kielillä tunnin ajan."
+---
+
 ### Kielillä puhuminen
 
 *3-piirin ennustaminen* 

--- a/Loitsut/Kielten_ymmärrys.md
+++ b/Loitsut/Kielten_ymmärrys.md
@@ -1,3 +1,8 @@
+---
+title: "Kielten ymmärrys"
+description: "Kielten ymmärrys on 1-piirin ennustamisloitsu, joka antaa loitsijan ymmärtää tunnin ajan mitä tahansa puhuttua ja kirjoitettua kieltä."
+---
+
 ### Kielten ymmärrys
 
 *1-piirin ennustaminen*

--- a/Loitsut/Kiiruhtaminen.md
+++ b/Loitsut/Kiiruhtaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kiiruhtaminen"
+description: "Kiiruhtaminen on 3-piirin muovaamisloitsu, joka antaa kohteelle puolustusbonuksen, edun ketteryysheittoihin ja ylimääräisen toiminnon vuorollaan."
+---
+
 ### Kiiruhtaminen
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Kilpi.md
+++ b/Loitsut/Kilpi.md
@@ -1,3 +1,8 @@
+---
+title: "Kilpi"
+description: "Kilpi on 1-piirin suojelureaktio, joka antaa loitsijalle viiden pisteen puolustusbonuksen ja torjuu noidannuolen vahingon kokonaan."
+---
+
 ### Kilpi
 
 *1-piirin suojelus*

--- a/Loitsut/Kirouksen_kumoaminen.md
+++ b/Loitsut/Kirouksen_kumoaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kirouksen kumoaminen"
+description: "Kirouksen kumoaminen on 3-piirin suojelusloitsu, joka poistaa kosketuksella kaikki kohteeseen vaikuttavat kiroukset ja niiden vaikutukset."
+---
+
 ### Kirouksen kumoaminen
 
 *3-piirin suojelus* 

--- a/Loitsut/Kirous.md
+++ b/Loitsut/Kirous.md
@@ -1,3 +1,8 @@
+---
+title: "Kirous"
+description: "Kirous on 3-piirin kuolontaikuusloitsu, joka asettaa kosketetulle kohteelle valittavan haitan, kuten heikentyneen ominaisuuden tai pelastusheiton."
+---
+
 ### Kirous
 
 *3-piirin kuolontaikuus* 

--- a/Loitsut/Kiveen_sulautuminen.md
+++ b/Loitsut/Kiveen_sulautuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kiveen sulautuminen"
+description: "Kiveen sulautuminen on 3-piirin muovaamisloitsu, joka piilottaa loitsijan varusteineen kiven sisään kahdeksan tunnin ajaksi havaitsemattomiin."
+---
+
 ### Kiveen sulautuminen
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Kivettävä_katse.md
+++ b/Loitsut/Kivettävä_katse.md
@@ -1,3 +1,8 @@
+---
+title: "Kivettävä katse"
+description: "Kivettävä katse on 6-piirin muovaamisloitsu, joka yrittää muuttaa kohteen kiveksi kolmen epäonnistuneen sitkeyspelastusheiton jälkeen."
+---
+
 ### Kivettävä katse
 
 *6-piirin muovaaminen*

--- a/Loitsut/Kivimuoto.md
+++ b/Loitsut/Kivimuoto.md
@@ -1,3 +1,8 @@
+---
+title: "Kivimuoto"
+description: "Kivimuoto on 4-piirin muovaamisloitsu, jolla koskettamansa kivilohkareen voi muotoilla aseeksi, patsaaksi tai käytäväksi kiviseinään."
+---
+
 ### Kivimuoto
 
 *4-piirin muovaaminen*

--- a/Loitsut/Kivinahka.md
+++ b/Loitsut/Kivinahka.md
@@ -1,3 +1,8 @@
+---
+title: "Kivinahka"
+description: "Kivinahka on 4-piirin suojelusloitsu, joka muuttaa kohteen ihon kivenkovaksi ja antaa sietokyvyn viilto-, pisto- ja murskausvahingolle tunniksi."
+---
+
 ### Kivinahka
 
 *4-piirin suojelus*

--- a/Loitsut/Kivivalli.md
+++ b/Loitsut/Kivivalli.md
@@ -1,3 +1,8 @@
+---
+title: "Kivivalli"
+description: "Kivivalli on 5-piirin luomisloitsu, joka nostaa maasta kivisen vallin, joka muodostuu neljä metriä korkeista tai leveistä laatoista."
+---
+
 ### Kivivalli
 
 *5-piirin luominen*

--- a/Loitsut/Kloonaus.md
+++ b/Loitsut/Kloonaus.md
@@ -1,3 +1,8 @@
+---
+title: "Kloonaus"
+description: "Kloonaus on 8-piirin kuolontaikuusloitsu, joka kasvattaa säiliössä elävästä olennosta kloonatun varakappaleen äkillisen kuoleman varalle."
+---
+
 ### Kloonaus
 
 *8-piirin kuolontaikuus*

--- a/Loitsut/Koputus.md
+++ b/Loitsut/Koputus.md
@@ -1,3 +1,8 @@
+---
+title: "Koputus"
+description: "Koputus on 2-piirin muovaamisloitsu, joka avaa yhden lukituista lukoista esineessä ja saa avattavasta kohteesta kuuluvan kovan koputusäänen."
+---
+
 ### Koputus
 
 *2-piirin muovaaminen*

--- a/Loitsut/Korventava_säde.md
+++ b/Loitsut/Korventava_säde.md
@@ -1,3 +1,8 @@
+---
+title: "Korventava säde"
+description: "Korventava säde on 2-piirin luomisloitsu, joka luo kolme tulista sädettä ja aiheuttaa 2n6 tulivahinkoa kutakin osuvaa sädettä kohden."
+---
+
 ### Korventava säde
 
 *2-piirin luominen*

--- a/Loitsut/Kunnostaminen.md
+++ b/Loitsut/Kunnostaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kunnostaminen"
+description: "Kunnostaminen on muovaamiseen kuuluva taikakonsti, joka paikkaa halkeaman tai repeämän kosketetussa esineessä, myös maagisessa rakennelmassa."
+---
+
 ### Kunnostaminen
 
 *Taikakonsti, muovaaminen*

--- a/Loitsut/Kuoleman_kehä.md
+++ b/Loitsut/Kuoleman_kehä.md
@@ -1,3 +1,8 @@
+---
+title: "Kuoleman kehä"
+description: "Kuoleman kehä on 6-piirin kuolontaikuusloitsu, joka levittää kuolonenergiaa 24 metrin pallossa aiheuttaen 8n6 kuolonvahinkoa sitkeysheitolla puolitettuna."
+---
+
 ### Kuoleman kehä
 
 *6-piirin kuolontaikuus*

--- a/Loitsut/Kuolleille_puhuminen.md
+++ b/Loitsut/Kuolleille_puhuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kuolleille puhuminen"
+description: "Kuolleille puhuminen on 3-piirin kuolontaikuusloitsu, joka herättää ruumiin väliaikaisesti vastaamaan enintään viiteen loitsijan kysymykseen."
+---
+
 ### Kuolleille puhuminen
 
 *3-piirin kuolontaikuus* 

--- a/Loitsut/Kuolleista_nostaminen.md
+++ b/Loitsut/Kuolleista_nostaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Kuolleista nostaminen"
+description: "Kuolleista nostaminen on 5-piirin kuolontaikuusloitsu, joka palauttaa kymmenen päivän sisällä kuolleen olennon henkiin yhdellä osumapisteellä."
+---
+
 ### Kuolleista nostaminen
 
 *5-piirin kuolontaikuus*

--- a/Loitsut/Kuolonsormi.md
+++ b/Loitsut/Kuolonsormi.md
@@ -1,3 +1,8 @@
+---
+title: "Kuolonsormi"
+description: "Kuolonsormi on 7-piirin kuolontaikuusloitsu, joka lähettää negatiivisen energian purkauksen aiheuttaen 7n8+30 kuolonvahinkoa sitkeysheitolla puolitettuna."
+---
+
 ### Kuolonsormi
 
 *7-piirin kuolontaikuus*

--- a/Loitsut/Kuunsäde.md
+++ b/Loitsut/Kuunsäde.md
@@ -1,3 +1,8 @@
+---
+title: "Kuunsäde"
+description: "Kuunsäde on 2-piirin luomisloitsu, joka luo hopeisen valopatsaan ja aiheuttaa 2n10 hohkavahinkoa sitkeyspelastusheitolla puolitettuna."
+---
+
 ### Kuunsäde
 
 *2-piirin luominen*

--- a/Loitsut/Kuvajainen.md
+++ b/Loitsut/Kuvajainen.md
@@ -1,3 +1,8 @@
+---
+title: "Kuvajainen"
+description: "Kuvajainen on 3-piirin illuusioloitsu, joka luo aidon näköisen, kuuloisen ja tuoksuvan kuvan esineestä tai olennosta 8x8x8 metrin kuutioon asti."
+---
+
 ### Kuvajainen
 
 *3-piirin illuusio* 

--- a/Loitsut/Kylmyyden_kehä.md
+++ b/Loitsut/Kylmyyden_kehä.md
@@ -1,3 +1,8 @@
+---
+title: "Kylmyyden kehä"
+description: "Kylmyyden kehä on 6-piirin luomisloitsu, joka räjäyttää jäätävän pallon kantamalla ja aiheuttaa 10n6 kylmävahinkoa sitkeys-pelastusheitolla puolitettuna."
+---
+
 ### Kylmyyden kehä
 
 *6-piirin luomimen*

--- a/Loitsut/Kylmänkosketus.md
+++ b/Loitsut/Kylmänkosketus.md
@@ -1,3 +1,8 @@
+---
+title: "Kylmänkosketus"
+description: "Kylmänkosketus on kuolontaikuuden taikakonsti, joka luo luurankokäden tekemään kantamahyökkäyksen ja aiheuttaa 1n8 kuolonvahinkoa kohteelle."
+---
+
 ### Kylmänkosketus
 
 *Taikakonsti, kuolontaikuus*

--- a/Loitsut/Käsky.md
+++ b/Loitsut/Käsky.md
@@ -1,3 +1,8 @@
+---
+title: "Käsky"
+description: "Käsky on 1-piirin lumoamisloitsu, jolla annetaan yhden sanan komento kohteelle, jonka on toteltava epäonnistuneen viisauspelastusheiton jälkeen."
+---
+
 ### Käsky
 
 *1-piirin lumoaminen*

--- a/Loitsut/Käänteispainovoima.md
+++ b/Loitsut/Käänteispainovoima.md
@@ -1,3 +1,8 @@
+---
+title: "Käänteispainovoima"
+description: "Käänteispainovoima on 7-piirin kutsumisloitsu, joka kääntää painovoiman sylinterin muotoisella alueella ja saa olennot putoamaan ylöspäin."
+---
+
 ### Käänteispainovoima
 
 *7-piirin kutsuminen*

--- a/Loitsut/Köysitemppu.md
+++ b/Loitsut/Köysitemppu.md
@@ -1,3 +1,8 @@
+---
+title: "Köysitemppu"
+description: "Köysitemppu on 2-piirin muovaamisloitsu, joka nostaa köyden pystyyn ja avaa sen yläpäähän piilotilan, jonne mahtuu kahdeksan olentoa."
+---
+
 ### Köysitemppu
 
 *2-piirin muovaaminen*

--- a/Loitsut/Labyrintti.md
+++ b/Loitsut/Labyrintti.md
@@ -1,3 +1,8 @@
+---
+title: "Labyrintti"
+description: "Labyrintti on 8-piirin kutsumisloitsu, joka karkottaa kohteen varjomaailman labyrinttiin, josta poispääsy vaatii onnistuneen älykkyysheiton."
+---
+
 ### Labyrintti
 
 *8-piirin kutsuminen*

--- a/Loitsut/Legenda.md
+++ b/Loitsut/Legenda.md
@@ -1,3 +1,8 @@
+---
+title: "Legenda"
+description: "Legenda on 5-piirin ennustamisloitsu, joka paljastaa loitsijan mieleen tietoa legendaarisesta henkilöstä, paikasta tai esineestä."
+---
+
 ### Legenda
 
 *5-piirin ennustaminen*

--- a/Loitsut/Leijuva_kiekko.md
+++ b/Loitsut/Leijuva_kiekko.md
@@ -1,3 +1,8 @@
+---
+title: "Leijuva kiekko"
+description: "Leijuva kiekko on 1-piirin kutsumisloitsu, joka luo ilmassa leijuvan, korkeintaan 220 kiloa kantavan maagisen kiekon loitsijan lähettyville."
+---
+
 ### Leijuva kiekko
 
 *1-piirin kutsuminen*

--- a/Loitsut/Lento.md
+++ b/Loitsut/Lento.md
@@ -1,3 +1,8 @@
+---
+title: "Lento"
+description: "Lento on 3-piirin muovaamisloitsu, joka antaa kosketetulle olennolle 24 metrin lentonopeuden loitsun keston ajaksi."
+---
+
 ### Lento
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Levitaatio.md
+++ b/Loitsut/Levitaatio.md
@@ -1,3 +1,8 @@
+---
+title: "Levitaatio"
+description: "Levitaatio on 2-piirin muovaamisloitsu, joka nostaa olennon tai esineen ilmaan korkeintaan kuuden metrin korkeuteen paikallaan pysyväksi."
+---
+
 ### Levitaatio
 
 *2-piirin muovaaminen*

--- a/Loitsut/Liekkikuula.md
+++ b/Loitsut/Liekkikuula.md
@@ -1,3 +1,8 @@
+---
+title: "Liekkikuula"
+description: "Liekkikuula on 2-piirin kutsumisloitsu, joka luo palavan pallon, joka aiheuttaa 2n6 vahinkoa lähellä oleville ketteryys-pelastusheitolla puolitettuna."
+---
+
 ### Liekkikuula
 
 *2-piirin kutsuminen*

--- a/Loitsut/Liekkipilari.md
+++ b/Loitsut/Liekkipilari.md
@@ -1,3 +1,8 @@
+---
+title: "Liekkipilari"
+description: "Liekkipilari on 5-piirin luomisloitsu, joka pudottaa taivaasta tulipilarin ja aiheuttaa yhteensä 8n6 tuli- ja hohkavahinkoa pelastusheitolla puolitettuna."
+---
+
 ### Liekkipilari
 
 *5-piirin luominen*

--- a/Loitsut/Liekkiterä.md
+++ b/Loitsut/Liekkiterä.md
@@ -1,3 +1,8 @@
+---
+title: "Liekkiterä"
+description: "Liekkiterä on 2-piirin luomisloitsu, joka synnyttää liekehtivän miekan käteen ja tekee 3n6 tulivahinkoa lähitaisteluosumalla."
+---
+
 ### Liekkiterä
 
 *2-piirin luominen*

--- a/Loitsut/Liikkuva_illuusio.md
+++ b/Loitsut/Liikkuva_illuusio.md
@@ -1,3 +1,8 @@
+---
+title: "Liikkuva illuusio"
+description: "Liikkuva illuusio on 6-piirin illuusioloitsu, joka luo ehtolaukaisimella käynnistyvän, enintään viisi minuuttia kestävän havaintonäytöksen."
+---
+
 ### Liikkuva illuusio
 
 *6-piirin illuusio*

--- a/Loitsut/Liikkuva_omakuva.md
+++ b/Loitsut/Liikkuva_omakuva.md
@@ -1,3 +1,8 @@
+---
+title: "Liikkuva omakuva"
+description: "Liikkuva omakuva on 7-piirin illuusioloitsu, joka luo aineettoman kaksoisolennon loitsijasta jopa 800 kilometrin päähän ohjattavaksi."
+---
+
 ### Liikkuva omakuva
 
 *7-piirin illuusio*

--- a/Loitsut/Linnoitus.md
+++ b/Loitsut/Linnoitus.md
@@ -1,3 +1,8 @@
+---
+title: "Linnoitus"
+description: "Linnoitus on 6-piirin suojelusloitsu, joka suojaa taikuudella 400 neliömetrin rakennuksen 24 tunnin ajan valittuja henkilöitä lukuun ottamatta."
+---
+
 ### Linnoitus
 
 *6-piirin suojelus*

--- a/Loitsut/Loitsumiekka.md
+++ b/Loitsut/Loitsumiekka.md
@@ -1,3 +1,8 @@
+---
+title: "Loitsumiekka"
+description: "Loitsumiekka on 7-piirin luomisloitsu, joka luo ilmassa leijuvan energiamiekan, jota loitsija ohjaa mielellään ja joka tekee 3n10 energiavahinkoa."
+---
+
 ### Loitsumiekka
 
 *7-piirin luominen*

--- a/Loitsut/Loitsunaamio.md
+++ b/Loitsut/Loitsunaamio.md
@@ -1,3 +1,8 @@
+---
+title: "Loitsunaamio"
+description: "Loitsunaamio on 2-piirin illuusioloitsu, joka antaa kosketetulle esineelle tai olennolle väärän auran tai naamion ennustusloitsuja vastaan."
+---
+
 ### Loitsunaamio
 
 *2-piirin illuusio*

--- a/Loitsut/Loitsut.md
+++ b/Loitsut/Loitsut.md
@@ -1,3 +1,8 @@
+---
+title: "Loitsut"
+description: "Loitsut-sivu listaa Legendoja ja Lohikäärmeitä -säännöstön kaikki loitsut piirin mukaan taikakonsteista yhdeksännen piirin loitsuihin asti."
+---
+
 # Loitsut
 
 Seuraavilla sivuilla löydät kuvaukset kaikista tunnetuista loitsuista. Loitsut on listattu piirin mukaan. Ensimmäisenä löytyvät taikakonstit ja viimeisimpänä kaikkein voimallisimmat yhdeksännen piirin loitsut.

--- a/Loitsut/Lounasmarja.md
+++ b/Loitsut/Lounasmarja.md
@@ -1,3 +1,8 @@
+---
+title: "Lounasmarja"
+description: "Lounasmarja on 1-piirin muovaamisloitsu, joka luo enintään kymmenen marjaa, joista jokainen palauttaa syöjälleen osumapisteen ja päivän ravinnon."
+---
+
 ### Lounasmarja
 
 *1-piirin muovaaminen*

--- a/Loitsut/Lumoaminen.md
+++ b/Loitsut/Lumoaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Lumoaminen"
+description: "Lumoaminen on 1-piirin lumoamisloitsu, joka tekee kohteesta ystävällismielisen loitsijaa kohtaan epäonnistuneen viisauspelastusheiton jälkeen."
+---
+
 ### Lumoaminen
 
 *1-piirin lumoaminen*

--- a/Loitsut/Luo_liekkejä.md
+++ b/Loitsut/Luo_liekkejä.md
@@ -1,3 +1,8 @@
+---
+title: "Luo liekkejä"
+description: "Luo liekkejä on kutsumisen taikakonsti, joka synnyttää käteen liekin, jonka voi heittää 12 metrin päähän aiheuttamaan 1n8 tulivahinkoa."
+---
+
 ### Luo liekkejä
 
 *Taikakonsti, kutsuminen*

--- a/Loitsut/Luominen.md
+++ b/Loitsut/Luominen.md
@@ -1,3 +1,8 @@
+---
+title: "Luominen"
+description: "Luominen on 5-piirin illuusioloitsu, joka muodostaa varjoaineesta enintään kahden metrin kuution esineen, jonka kesto vaihtelee materiaalin mukaan."
+---
+
 ### Luominen
 
 *5-piirin illuusio*

--- a/Loitsut/Luontoyhteys.md
+++ b/Loitsut/Luontoyhteys.md
@@ -1,3 +1,8 @@
+---
+title: "Luontoyhteys"
+description: "Luontoyhteys on 5-piirin ennustamisloitsu, joka paljastaa hetkessä tietoa lähialueen maastosta, olennoista ja vaaroista laajalta säteeltä."
+---
+
 ### Luontoyhteys
 
 *5-piirin ennustaminen*

--- a/Loitsut/Löyhkäävä_pilvi.md
+++ b/Loitsut/Löyhkäävä_pilvi.md
@@ -1,3 +1,8 @@
+---
+title: "Löyhkäävä pilvi"
+description: "Löyhkäävä pilvi on 3-piirin kutsumisloitsu, joka luo 8 metrin säteisen myrkkypilven, jonka sisällä oleva joutuu heittämään sitkeys-pelastusheiton."
+---
+
 ### Löyhkäävä pilvi
 
 *3-piirin kutsuminen* 

--- a/Loitsut/Maaginen_kangastus.md
+++ b/Loitsut/Maaginen_kangastus.md
@@ -1,3 +1,8 @@
+---
+title: "Maaginen kangastus"
+description: "Maaginen kangastus on 7-piirin illuusioloitsu, joka muuttaa laajan neliökilometrin alueen näyttämään ja tuntumaan kymmenen päivän ajan toiselta maastolta."
+---
+
 ### Maaginen kangastus
 
 *7-piirin illuusio*

--- a/Loitsut/Maaginen_kopio.md
+++ b/Loitsut/Maaginen_kopio.md
@@ -1,3 +1,8 @@
+---
+title: "Maaginen kopio"
+description: "Maaginen kopio on 7-piirin illuusioloitsu, joka muodostaa lumesta tai jäästä toimivan kaksoisolennon kopioitavasta eläimestä tai humanoidista."
+---
+
 ### Maaginen kopio
 
 *7-piirin illuusio*

--- a/Loitsut/Maaginen_pako.md
+++ b/Loitsut/Maaginen_pako.md
@@ -1,3 +1,8 @@
+---
+title: "Maaginen pako"
+description: "Maaginen pako on 6-piirin kutsumisloitsu, joka teleporttaa loitsijan ja jopa viisi muuta olentoa välittömästi ennalta määriteltyyn turvapaikkaan."
+---
+
 ### Maaginen pako
 
 *6-piirin kutsuminen*

--- a/Loitsut/Maaginen_piilo.md
+++ b/Loitsut/Maaginen_piilo.md
@@ -1,3 +1,8 @@
+---
+title: "Maaginen piilo"
+description: "Maaginen piilo on 7-piirin muovaamisloitsu, joka tekee vapaaehtoisesta olennosta tai esineestä näkymättömän ja pysäyttää sen ajan kulun."
+---
+
 ### Maaginen piilo
 
 *7-piirin muovaaminen*

--- a/Loitsut/Maaginen_symboli.md
+++ b/Loitsut/Maaginen_symboli.md
@@ -1,3 +1,8 @@
+---
+title: "Maaginen symboli"
+description: "Maaginen symboli on 7-piirin suojelusloitsu, joka luo pintaan tai esineeseen torjuvan merkin, joka laukeaa loitsijan asettamin ehdoin."
+---
+
 ### Maaginen symboli
 
 *7-piirin suojelus*

--- a/Loitsut/Maaginpanssari.md
+++ b/Loitsut/Maaginpanssari.md
@@ -1,3 +1,8 @@
+---
+title: "Maaginpanssari"
+description: "Maaginpanssari on 1-piirin suojelusloitsu, joka nostaa haarniskattoman kohteen puolustuksen arvoon 13 plus ketteryysbonus kahdeksan tunnin ajaksi."
+---
+
 ### Maaginpanssari
 
 *1-piirin suojelus*

--- a/Loitsut/Maanjäristys.md
+++ b/Loitsut/Maanjäristys.md
@@ -1,3 +1,8 @@
+---
+title: "Maanjäristys"
+description: "Maanjäristys on 8-piirin luomisloitsu, joka saa maan järisemään 40 metrin säteellä, katkaisee keskittymisen ja vahingoittaa rakennuksia."
+---
+
 ### Maanjäristys
 
 *8-piirin luominen*

--- a/Loitsut/Maanmuokkaus.md
+++ b/Loitsut/Maanmuokkaus.md
@@ -1,3 +1,8 @@
+---
+title: "Maanmuokkaus"
+description: "Maanmuokkaus on 6-piirin muovaamisloitsu, jolla voi kaivaa, täyttää, nostaa tai madaltaa maastoa 16 metrin alueella kahden tunnin ajan."
+---
+
 ### Maanmuokkaus
 
 *6-piirin muovaaminen*

--- a/Loitsut/Magian_löytäminen.md
+++ b/Loitsut/Magian_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Magian löytäminen"
+description: "Magian löytäminen on 1-piirin ennustamisrituaali, joka aistii maagisen läsnäolon ja paljastaa löydetyn esineen tai olennon koulukunnan."
+---
+
 ### Magian löytäminen
 
 *1-piirin ennustaminen (rituaali)*

--- a/Loitsut/Maja.md
+++ b/Loitsut/Maja.md
@@ -1,3 +1,8 @@
+---
+title: "Maja"
+description: "Maja on 3-piirin luomisrituaali, joka luo läpäisemättömän puolipallon kuvun, joka suojaa loitsijaa ja yhdeksää muuta olentoa kahdeksan tuntia."
+---
+
 ### Maja
 
 *3-piirin luominen (rituaali)* 

--- a/Loitsut/Meteorimyrsky.md
+++ b/Loitsut/Meteorimyrsky.md
@@ -1,3 +1,8 @@
+---
+title: "Meteorimyrsky"
+description: "Meteorimyrsky on 9-piirin luomisloitsu, joka pudottaa neljä tulipalloa maahan ja aiheuttaa massiivisen tuli- ja murskausvahingon puolitettuna."
+---
+
 ### Meteorimyrsky
 
 *9-piirin luominen*

--- a/Loitsut/Metsäharppaus.md
+++ b/Loitsut/Metsäharppaus.md
@@ -1,3 +1,8 @@
+---
+title: "Metsäharppaus"
+description: "Metsäharppaus on 5-piirin kutsumisloitsu, joka antaa kyvyn liikkua puun sisään ja ulos toisesta samanlajisesta puusta 200 metrin säteellä."
+---
+
 ### Metsäharppaus
 
 *5-piirin kutsuminen*

--- a/Loitsut/Metsän_olentojen_kutsuminen.md
+++ b/Loitsut/Metsän_olentojen_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Metsän olentojen kutsuminen"
+description: "Metsän olentojen kutsuminen on 4-piirin kutsumisloitsu, joka tuo avuksi ystävällisiä keijuolentoja valitun haastearvon mukaan tunnin ajaksi."
+---
+
 ### Metsän olentojen kutsuminen
 
 *4-piirin kutsuminen*

--- a/Loitsut/Metsästäjän_merkki.md
+++ b/Loitsut/Metsästäjän_merkki.md
@@ -1,3 +1,8 @@
+---
+title: "Metsästäjän merkki"
+description: "Metsästäjän merkki on 1-piirin ennustamisloitsu, joka tuottaa 1n6 lisävahinkoa valittuun saaliiseen ja antaa edun sen jäljittämiseen tunnin ajan."
+---
+
 ### Metsästäjän merkki
 
 *1-piirin ennustaminen*

--- a/Loitsut/Miekkavalli.md
+++ b/Loitsut/Miekkavalli.md
@@ -1,3 +1,8 @@
+---
+title: "Miekkavalli"
+description: "Miekkavalli on 6-piirin luomisloitsu, joka luo pyörivien terien seinämän tai kehän, jonka läpi kulkeva joutuu heittämään ketteryys-pelastusheiton."
+---
+
 ### Miekkavalli
 
 *6-piirin luominen*

--- a/Loitsut/Muistinmuokkaus.md
+++ b/Loitsut/Muistinmuokkaus.md
@@ -1,3 +1,8 @@
+---
+title: "Muistinmuokkaus"
+description: "Muistinmuokkaus on 5-piirin lumoamisloitsu, joka lumoaa kohteen toimintakyvyttömäksi ja mahdollistaa muistojen muokkaamisen pelastusheiton epäonnistuessa."
+---
+
 ### Muistinmuokkaus
 
 *5-piirin lumoaminen*

--- a/Loitsut/Muodonmuokkaus.md
+++ b/Loitsut/Muodonmuokkaus.md
@@ -1,3 +1,8 @@
+---
+title: "Muodonmuokkaus"
+description: "Muodonmuokkaus on 9-piirin muovaamisloitsu, joka muuttaa olennon toiseksi olennoksi, olennon esineeksi tai esineen olennoksi tunnin ajaksi."
+---
+
 ### Muodonmuokkaus
 
 *9-piirin muovaaminen*

--- a/Loitsut/Muodonmuutos.md
+++ b/Loitsut/Muodonmuutos.md
@@ -1,3 +1,8 @@
+---
+title: "Muodonmuutos"
+description: "Muodonmuutos on 9-piirin muovaamisloitsu, joka muuttaa loitsijan minkä tahansa haastearvoltaan sopivan olennon muotoon tunnin ajaksi."
+---
+
 ### Muodonmuutos
 
 *9-piirin muovaaminen*

--- a/Loitsut/Muodonvaihdos.md
+++ b/Loitsut/Muodonvaihdos.md
@@ -1,3 +1,8 @@
+---
+title: "Muodonvaihdos"
+description: "Muodonvaihdos on 4-piirin muovaamisloitsu, joka muuttaa kohteen eläimen muotoon, jonka haastearvo vastaa kohteen tasoa, tunnin ajaksi."
+---
+
 ### Muodonvaihdos
 
 *4-piirin muovaaminen*

--- a/Loitsut/Mustat_lonkerot.md
+++ b/Loitsut/Mustat_lonkerot.md
@@ -1,3 +1,8 @@
+---
+title: "Mustat lonkerot"
+description: "Mustat lonkerot on 4-piirin kutsumisloitsu, joka täyttää 8x8 metrin alueen sitovilla lonkeroilla, jotka aiheuttavat 3n6 murskausvahinkoa."
+---
+
 ### Mustat lonkerot
 
 *4-piirin kutsuminen*

--- a/Loitsut/Mykkä_kuvajainen.md
+++ b/Loitsut/Mykkä_kuvajainen.md
@@ -1,3 +1,8 @@
+---
+title: "Mykkä kuvajainen"
+description: "Mykkä kuvajainen on 1-piirin illuusioloitsu, joka luo äänettömän kuvan esineestä tai olennosta korkeintaan 6x6x6 metrin kuutioon."
+---
+
 ### Mykkä kuvajainen
 
 *1-piirin illuusio*

--- a/Loitsut/Myrkkypilvi.md
+++ b/Loitsut/Myrkkypilvi.md
@@ -1,3 +1,8 @@
+---
+title: "Myrkkypilvi"
+description: "Myrkkypilvi on 5-piirin kutsumisloitsu, joka luo 8 metrin säteisen myrkkysumun ja aiheuttaa 5n8 myrkkyvahinkoa sitkeys-pelastusheitolla puolitettuna."
+---
+
 ### Myrkkypilvi
 
 *5-piirin kutsuminen*

--- a/Loitsut/Myrkkysuihku.md
+++ b/Loitsut/Myrkkysuihku.md
@@ -1,3 +1,8 @@
+---
+title: "Myrkkysuihku"
+description: "Myrkkysuihku on kutsumisen taikakonsti, joka suihkuttaa myrkyllistä kaasua kohteeseen aiheuttaen 1n12 myrkkyvahinkoa epäonnistuneella sitkeysheitolla."
+---
+
 ### Myrkkysuihku
 
 *Taikakonsti, kutsuminen*

--- a/Loitsut/Myrkyn_ja_taudin_löytäminen.md
+++ b/Loitsut/Myrkyn_ja_taudin_löytäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Myrkyn ja taudin löytäminen"
+description: "Myrkyn ja taudin löytäminen on 1-piirin ennustamisrituaali, joka aistii myrkyt, myrkylliset olennot ja taudit 12 metrin säteellä loitsijasta."
+---
+
 ### Myrkyn ja taudin löytäminen
 
 *1-piirin ennustaminen (rituaali)*

--- a/Loitsut/Myrskyvalli.md
+++ b/Loitsut/Myrskyvalli.md
@@ -1,3 +1,8 @@
+---
+title: "Myrskyvalli"
+description: "Myrskyvalli on 3-piirin luomisloitsu, joka nostaa tuulesta esteen ja aiheuttaa 3n8 murskausvahinkoa voimakkuus-pelastusheitolla puolitettuna."
+---
+
 ### Myrskyvalli
 
 *3-piirin luominen* 

--- a/Loitsut/Mystinen_side.md
+++ b/Loitsut/Mystinen_side.md
@@ -1,3 +1,8 @@
+---
+title: "Mystinen side"
+description: "Mystinen side on 2-piirin suojelusloitsu, joka luo loitsijan ja kohteen välille siteen, jossa kohteen kärsimä vahinko jaetaan loitsijan kanssa."
+---
+
 ### Mystinen side
 
 *2-piirin suojelus*

--- a/Loitsut/Naurukohtaus.md
+++ b/Loitsut/Naurukohtaus.md
@@ -1,3 +1,8 @@
+---
+title: "Naurukohtaus"
+description: "Naurukohtaus on 1-piirin lumoamisloitsu, joka lamaannuttaa kohteen naurukohtaukseen epäonnistuneen viisauspelastusheiton seurauksena."
+---
+
 ### Naurukohtaus
 
 *1-piirin lumoaminen*

--- a/Loitsut/Noidannuoli.md
+++ b/Loitsut/Noidannuoli.md
@@ -1,3 +1,8 @@
+---
+title: "Noidannuoli"
+description: "Noidannuoli on 1-piirin luomisloitsu, joka ampuu kolme maagista nuolta, joista kukin tekee 1n4+1 energiavahinkoa valittuihin kohteisiin."
+---
+
 ### Noidannuoli
 
 *1-piirin luominen*

--- a/Loitsut/Noidansilmät.md
+++ b/Loitsut/Noidansilmät.md
@@ -1,3 +1,8 @@
+---
+title: "Noidansilmät"
+description: "Noidansilmät on 6-piirin kuolontaikuusloitsu, joka pakottaa kohteen viisauspelastusheittoon kärsimään pahaenteisen vaikutuksen, kuten unen tai kauhun."
+---
+
 ### Noidansilmät
 
 *6-piirin kuolontaikuus*

--- a/Loitsut/Nopea_pako.md
+++ b/Loitsut/Nopea_pako.md
@@ -1,3 +1,8 @@
+---
+title: "Nopea pako"
+description: "Nopea pako on 1-piirin muovaamisloitsu, joka antaa bonustoiminnon ryntäykseen loitsun keston ajan, jopa 10 minuutin verran."
+---
+
 ### Nopea pako
 
 *1-piirin muovaaminen*

--- a/Loitsut/Näkymättömyys.md
+++ b/Loitsut/Näkymättömyys.md
@@ -1,3 +1,8 @@
+---
+title: "Näkymättömyys"
+description: "Näkymättömyys on 2-piirin illuusioloitsu, joka tekee kosketetusta olennosta ja sen varusteista näkymättömän tunnin ajaksi."
+---
+
 ### Näkymättömyys
 
 *2-piirin illuusio*

--- a/Loitsut/Näkymättömän_näkeminen.md
+++ b/Loitsut/Näkymättömän_näkeminen.md
@@ -1,3 +1,8 @@
+---
+title: "Näkymättömän näkeminen"
+description: "Näkymättömän näkeminen on 2-piirin ennustamisloitsu, joka antaa kyvyn nähdä näkymättömät olennot ja eetteritason tunnin ajan."
+---
+
 ### Näkymättömän näkeminen
 
 *2-piirin ennustaminen*

--- a/Loitsut/Näkymätön_palvelija.md
+++ b/Loitsut/Näkymätön_palvelija.md
@@ -1,3 +1,8 @@
+---
+title: "Näkymätön palvelija"
+description: "Näkymätön palvelija on 1-piirin kutsumisrituaali, joka luo heikon, näkymättömän voiman tekemään pieniä tehtäviä loitsijan puolesta tunnin ajan."
+---
+
 ### Näkymätön palvelija
 
 *1-piirin kutsuminen (rituaali)*

--- a/Loitsut/Okavalli.md
+++ b/Loitsut/Okavalli.md
@@ -1,3 +1,8 @@
+---
+title: "Okavalli"
+description: "Okavalli on 6-piirin kutsumisloitsu, joka luo terävän pensasmuurin ja aiheuttaa 7n8 pistovahinkoa ilmestyessään sen alueelle jääville."
+---
+
 ### Okavalli
 
 *6-piirin kutsuminen*

--- a/Loitsut/Ominaisuuden_korotus.md
+++ b/Loitsut/Ominaisuuden_korotus.md
@@ -1,3 +1,8 @@
+---
+title: "Ominaisuuden korotus"
+description: "Ominaisuuden korotus on 2-piirin muovaamisloitsu, joka antaa kosketetulle olennolle valitun eläimellisen kyvyn, kuten karhun kestävyyden, tunniksi."
+---
+
 ### Ominaisuuden korotus
 
 *2-piirin muovaaminen*

--- a/Loitsut/Opastus.md
+++ b/Loitsut/Opastus.md
@@ -1,3 +1,8 @@
+---
+title: "Opastus"
+description: "Opastus on ennustamisen taikakonsti, joka antaa suostuvaiselle kohteelle mahdollisuuden lisätä 1n4 valitsemaansa ominaisuusheittoon."
+---
+
 ### Opastus
 
 *Taikakonsti, ennustaminen*

--- a/Loitsut/Oudotus.md
+++ b/Loitsut/Oudotus.md
@@ -1,3 +1,8 @@
+---
+title: "Oudotus"
+description: "Oudotus on 9-piirin illuusioloitsu, joka kutsuu esiin kohteiden pahimpiin painajaisiin perustuvia harhakuvia ja tekee heidät kauhistuneiksi."
+---
+
 ### Oudotus
 
 *9-piirin illuusio*

--- a/Loitsut/Paikanna_olento.md
+++ b/Loitsut/Paikanna_olento.md
@@ -1,3 +1,8 @@
+---
+title: "Paikanna olento"
+description: "Paikanna olento on 4-piirin ennustamisloitsu, joka paljastaa loitsijalle tunnetun olennon sijaintisuunnan 400 metrin etäisyydellä."
+---
+
 ### Paikanna olento
 
 *4-piirin ennustaminen*

--- a/Loitsut/Paineaalto.md
+++ b/Loitsut/Paineaalto.md
@@ -1,3 +1,8 @@
+---
+title: "Paineaalto"
+description: "Paineaalto on 1-piirin luomisloitsu, joka lähettää voimaaltoja 6x6x6 metrin kuutioon aiheuttaen 2n8 ukkosvahinkoa ja puskien olentoja poispäin."
+---
+
 ### Paineaalto
 
 *1-piirin luominen*

--- a/Loitsut/Pakko.md
+++ b/Loitsut/Pakko.md
@@ -1,3 +1,8 @@
+---
+title: "Pakko"
+description: "Pakko on 4-piirin lumoamisloitsu, joka pakottaa viisauspelastusheitossa epäonnistuneet kohteet liikkumaan loitsijan määräämään suuntaan."
+---
+
 ### Pakko
 
 *4-piirin lumoaminen*

--- a/Loitsut/Palava_käsi.md
+++ b/Loitsut/Palava_käsi.md
@@ -1,3 +1,8 @@
+---
+title: "Palava käsi"
+description: "Palava käsi on 1-piirin luomisloitsu, joka syöksee liekkejä kuusimetrisenä kartiona aiheuttaen 3n6 tulivahinkoa ketteryys-pelastusheitolla puolitettuna."
+---
+
 ### Palava käsi
 
 *1-piirin luominen*

--- a/Loitsut/Parannuksen_mahtisana.md
+++ b/Loitsut/Parannuksen_mahtisana.md
@@ -1,3 +1,8 @@
+---
+title: "Parannuksen mahtisana"
+description: "Parannuksen mahtisana on 3-piirin luomisloitsu, joka parantaa enintään kuusi kohdetta 1n4 plus loitsimisominaisuuden verran osumapisteitä."
+---
+
 ### Parannuksen mahtisana
 
 *3-piirin luominen* 

--- a/Loitsut/Parantaminen.md
+++ b/Loitsut/Parantaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Parantaminen"
+description: "Parantaminen on 6-piirin luomisloitsu, joka palauttaa kohteelle 70 osumapistettä ja poistaa sokeuden, kuurouden ja taudit kokonaan."
+---
+
 ### Parantaminen
 
 *6-piirin luominen*

--- a/Loitsut/Parantava_sana.md
+++ b/Loitsut/Parantava_sana.md
@@ -1,3 +1,8 @@
+---
+title: "Parantava sana"
+description: "Parantava sana on 1-piirin luomisloitsu, joka palauttaa bonustoimintona 1n4 plus loitsimisominaisuuden verran osumapisteitä näköpiirissä olevalle."
+---
+
 ### Parantava sana
 
 *1-piirin luominen*

--- a/Loitsut/Peilikuva.md
+++ b/Loitsut/Peilikuva.md
@@ -1,3 +1,8 @@
+---
+title: "Peilikuva"
+description: "Peilikuva on 2-piirin illuusioloitsu, joka luo loitsijasta kolme liikkuvaa kopiota, joihin vihollisen hyökkäykset saattavat osua sattumanvaraisesti."
+---
+
 ### Peilikuva
 
 *2-piirin illuusio*

--- a/Loitsut/Pelko.md
+++ b/Loitsut/Pelko.md
@@ -1,3 +1,8 @@
+---
+title: "Pelko"
+description: "Pelko on 3-piirin illuusioloitsu, joka luo pahimman pelon kuvan 12 metrin kartioon ja saa kohteet kauhistuneena ryntäämään pois loitsijan luota."
+---
+
 ### Pelko
 
 *3-piirin illuusio* 

--- a/Loitsut/Pienten_elementaalien_kutsuminen.md
+++ b/Loitsut/Pienten_elementaalien_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Pienten elementaalien kutsuminen"
+description: "Pienten elementaalien kutsuminen on 4-piirin kutsumisloitsu, joka tuo avuksi ystävällisiä elementaaliolentoja valitun haastearvon mukaan tunniksi."
+---
+
 ### Pienten elementaalien kutsuminen
 
 *4-piirin kutsuminen*

--- a/Loitsut/Piikkipensas.md
+++ b/Loitsut/Piikkipensas.md
@@ -1,3 +1,8 @@
+---
+title: "Piikkipensas"
+description: "Piikkipensas on 2-piirin muovaamisloitsu, joka kasvattaa 8 metrin säteelle piikkisen pensaikon, joka tekee 2n4 pistovahinkoa läpi kulkevalle."
+---
+
 ### Piikkipensas
 
 *2-piirin muovaaminen*

--- a/Loitsut/Piina.md
+++ b/Loitsut/Piina.md
@@ -1,3 +1,8 @@
+---
+title: "Piina"
+description: "Piina on 1-piirin lumoamisloitsu, joka heikentää enintään kolmen kohteen hyökkäys- ja pelastusheittoja 1n4:llä epäonnistuneen karismaheiton jälkeen."
+---
+
 ### Piina
 
 *1-piirin lumoaminen*

--- a/Loitsut/Pikamarssi.md
+++ b/Loitsut/Pikamarssi.md
@@ -1,3 +1,8 @@
+---
+title: "Pikamarssi"
+description: "Pikamarssi on 1-piirin muovaamisloitsu, joka kasvattaa kosketetun olennon liikkumisnopeutta neljällä metrillä tunnin ajaksi."
+---
+
 ### Pikamarssi
 
 *1-piirin muovaaminen*

--- a/Loitsut/Pimeys.md
+++ b/Loitsut/Pimeys.md
@@ -1,3 +1,8 @@
+---
+title: "Pimeys"
+description: "Pimeys on 2-piirin luomisloitsu, joka luo kuuden metrin säteisen maagisen pimeyden, jota ei voi läpäistä pimeänäöllä eikä luonnollisella valolla."
+---
+
 ### Pimeys
 
 *2-piirin luominen*

--- a/Loitsut/Pimeänäkö.md
+++ b/Loitsut/Pimeänäkö.md
@@ -1,3 +1,8 @@
+---
+title: "Pimeänäkö"
+description: "Pimeänäkö on 2-piirin muovaamisloitsu, joka antaa kosketetulle olennolle pimeänäön 24 metrin päähän kahdeksan tunnin ajaksi."
+---
+
 ### Pimeänäkö
 
 *2-piirin muovaaminen*

--- a/Loitsut/Pirstominen.md
+++ b/Loitsut/Pirstominen.md
@@ -1,3 +1,8 @@
+---
+title: "Pirstominen"
+description: "Pirstominen on 2-piirin luomisloitsu, joka luo vihlovan äänen ja tekee 3n8 ukkosvahinkoa neljän metrin säteellä sitkeys-pelastusheitolla puolitettuna."
+---
+
 ### Pirstominen
 
 *2-piirin luominen*

--- a/Loitsut/Polttava_pilvi.md
+++ b/Loitsut/Polttava_pilvi.md
@@ -1,3 +1,8 @@
+---
+title: "Polttava pilvi"
+description: "Polttava pilvi on 8-piirin kutsumisloitsu, joka luo 8 metrin säteisen tulipilven ja aiheuttaa 10n8 tulivahinkoa ketteryys-pelastusheitolla puolitettuna."
+---
+
 ### Polttava pilvi
 
 *8-piirin kutsuminen*

--- a/Loitsut/Punahehku.md
+++ b/Loitsut/Punahehku.md
@@ -1,3 +1,8 @@
+---
+title: "Punahehku"
+description: "Punahehku on 2-piirin muovaamisloitsu, joka kuumentaa metalliesineen punahehkuiseksi aiheuttaen kantajalleen 2n8 tulivahinkoa toistuvasti."
+---
+
 ### Punahehku
 
 *2-piirin muovaaminen*

--- a/Loitsut/Puunuija.md
+++ b/Loitsut/Puunuija.md
@@ -1,3 +1,8 @@
+---
+title: "Puunuija"
+description: "Puunuija on muovaamisen taikakonsti, joka tekee pidellystä nuijasta tai sauvasta maagisen aseen, jonka lyönnit tekevät 1n8 murskausvahinkoa."
+---
+
 ### Puunuija
 
 *Taikakonsti, muovaaminen*

--- a/Loitsut/Pyhittäminen.md
+++ b/Loitsut/Pyhittäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Pyhittäminen"
+description: "Pyhittäminen on 5-piirin luomisloitsu, joka täyttää 24 metrin alueen pyhällä tai epäpyhällä voimalla, joka estää taivaallisia, piruja ja epäkuolleita."
+---
+
 ### Pyhittäminen
 
 *5-piirin luominen*

--- a/Loitsut/Pyhä_kehä.md
+++ b/Loitsut/Pyhä_kehä.md
@@ -1,3 +1,8 @@
+---
+title: "Pyhä kehä"
+description: "Pyhä kehä on 8-piirin suojelusloitsu, joka antaa valituille olennoille edun pelastusheittoihin ja haitan vihollisten hyökkäyksiin 12 metrin säteellä."
+---
+
 ### Pyhä kehä
 
 *8-piirin suojelus*

--- a/Loitsut/Pyhä_liekki.md
+++ b/Loitsut/Pyhä_liekki.md
@@ -1,3 +1,8 @@
+---
+title: "Pyhä liekki"
+description: "Pyhä liekki on luomisen taikakonsti, joka ympäröi kohteen liekkien hohteella ja aiheuttaa 1n8 hohkavahinkoa epäonnistuneella ketteryysheitolla."
+---
+
 ### Pyhä liekki
 
 *Taikakonsti, luominen*

--- a/Loitsut/Pysäytys.md
+++ b/Loitsut/Pysäytys.md
@@ -1,3 +1,8 @@
+---
+title: "Pysäytys"
+description: "Pysäytys on 2-piirin lumoamisloitsu, joka halvaannuttaa kohteena olevan humanoidin epäonnistuneen viisauspelastusheiton jälkeen loitsun keston ajaksi."
+---
+
 ### Pysäytys
 
 *2-piirin lumoaminen*

--- a/Loitsut/Päivänvalo.md
+++ b/Loitsut/Päivänvalo.md
@@ -1,3 +1,8 @@
+---
+title: "Päivänvalo"
+description: "Päivänvalo on 3-piirin luomisloitsu, joka luo 24 metrin säteelle kirkkaan valon tunnin ajaksi ja purkaa heikommat pimeys-loitsut."
+---
+
 ### Päivänvalo
 
 *3-piirin luominen* 

--- a/Loitsut/Raivoava_myrsky.md
+++ b/Loitsut/Raivoava_myrsky.md
@@ -1,3 +1,8 @@
+---
+title: "Raivoava myrsky"
+description: "Raivoava myrsky on 9-piirin kutsumisloitsu, joka nostaa myrskypilvet 144 metrin säteelle ja tuottaa vuorolta vuorolle uusia salama- ja tuulivaikutuksia."
+---
+
 ### Raivoava myrsky
 
 *9-piirin kutsuminen*

--- a/Loitsut/Rasvalammikko.md
+++ b/Loitsut/Rasvalammikko.md
@@ -1,3 +1,8 @@
+---
+title: "Rasvalammikko"
+description: "Rasvalammikko on 1-piirin kutsumisloitsu, joka peittää 4x4 metrin alueen liukkaalla rasvalla, jolloin epäonnistunut ketteryysheitto kaataa olennon maahan."
+---
+
 ### Rasvalammikko
 
 *1-piirin kutsuminen*

--- a/Loitsut/Rauhoittaminen.md
+++ b/Loitsut/Rauhoittaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Rauhoittaminen"
+description: "Rauhoittaminen on 2-piirin lumoamisloitsu, joka viilentää väkijoukon tunteita ja voi vaimentaa lumouksen tai kauhistumisen 8 metrin säteellä."
+---
+
 ### Rauhoittaminen
 
 *2-piirin lumoaminen*

--- a/Loitsut/Regeneraatio.md
+++ b/Loitsut/Regeneraatio.md
@@ -1,3 +1,8 @@
+---
+title: "Regeneraatio"
+description: "Regeneraatio on 7-piirin muovaamisloitsu, joka palauttaa kosketetulle olennolle 4n8+15 osumapistettä ja kasvattaa katkenneet ruumiinosat takaisin."
+---
+
 ### Regeneraatio
 
 *7-piirin muovaaminen*

--- a/Loitsut/Reittihaku.md
+++ b/Loitsut/Reittihaku.md
@@ -1,3 +1,8 @@
+---
+title: "Reittihaku"
+description: "Reittihaku on 6-piirin ennustamisloitsu, joka paljastaa lyhimmän reitin tarkasti määriteltyyn sijaintiin samalla maailmatasolla vuorokauden ajaksi."
+---
+
 ### Reittihaku
 
 *6-piirin ennustaminen*

--- a/Loitsut/Rukouksella_parantaminen.md
+++ b/Loitsut/Rukouksella_parantaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Rukouksella parantaminen"
+description: "Rukouksella parantaminen on 2-piirin luomisloitsu, joka parantaa enintään kuusi kohdetta 2n8 plus loitsimismuuttujan verran osumapisteitä."
+---
+
 ### Rukouksella parantaminen
 
 *2-piirin luominen*

--- a/Loitsut/Ruoan_ja_juoman_puhdistus.md
+++ b/Loitsut/Ruoan_ja_juoman_puhdistus.md
@@ -1,3 +1,8 @@
+---
+title: "Ruoan ja juoman puhdistus"
+description: "Ruoan ja juoman puhdistus on 1-piirin muovaamisrituaali, joka poistaa taudit ja myrkyt kahden metrin säteellä olevasta ei-maagisesta ravinnosta."
+---
+
 ### Ruoan ja juoman puhdistus
 
 *1-piirin muovaaminen (rituaali)*

--- a/Loitsut/Räntäsade.md
+++ b/Loitsut/Räntäsade.md
@@ -1,3 +1,8 @@
+---
+title: "Räntäsade"
+description: "Räntäsade on 3-piirin kutsumisloitsu, joka luo 16 metrin säteisen jääalueen, jossa liikkuva joutuu heittämään ketteryys-pelastusheiton kaatumista vastaan."
+---
+
 ### Räntäsade
 
 *3-piirin kutsuminen* 

--- a/Loitsut/Salakirjoitus.md
+++ b/Loitsut/Salakirjoitus.md
@@ -1,3 +1,8 @@
+---
+title: "Salakirjoitus"
+description: "Salakirjoitus on 1-piirin illuusiorituaali, joka kirjoittaa tekstin niin, että vain valitut lukijat näkevät sen todellisen sisällön kymmenen päivän ajan."
+---
+
 ### Salakirjoitus
 
 *1-piirin illuusio (rituaali)*

--- a/Loitsut/Salama.md
+++ b/Loitsut/Salama.md
@@ -1,3 +1,8 @@
+---
+title: "Salama"
+description: "Salama on 3-piirin luomisloitsu, joka iskee 40 metrin linjana ja aiheuttaa 8n6 salamavahinkoa ketteryys-pelastusheitolla puolitettuna."
+---
+
 ### Salama
 
 *3-piirin luominen* 

--- a/Loitsut/Sallimus.md
+++ b/Loitsut/Sallimus.md
@@ -1,3 +1,8 @@
+---
+title: "Sallimus"
+description: "Sallimus on 1-piirin luomisloitsu, joka lisää loitsijan aseellisiin hyökkäyksiin 1n4 ylimääräistä hohkavahinkoa loitsun keston ajan."
+---
+
 ### Sallimus
 
 *1-piirin luominen*

--- a/Loitsut/Sammumaton_liekki.md
+++ b/Loitsut/Sammumaton_liekki.md
@@ -1,3 +1,8 @@
+---
+title: "Sammumaton liekki"
+description: "Sammumaton liekki on 2-piirin luomisloitsu, joka sytyttää kosketettuun esineeseen kuumentumattoman maagisen liekin, joka palaa pysyvästi ilman happea."
+---
+
 ### Sammumaton liekki
 
 *2-piirin luominen*

--- a/Loitsut/Sankarten_ateria.md
+++ b/Loitsut/Sankarten_ateria.md
@@ -1,3 +1,8 @@
+---
+title: "Sankarten ateria"
+description: "Sankarten ateria on 6-piirin kutsumisloitsu, joka järjestää juhla-aterian, joka parantaa taudeista, antaa myrkkyimmuniteetin ja lisää osumapistemaksimia."
+---
+
 ### Sankarten ateria
 
 *6-piirin kutsuminen*

--- a/Loitsut/Sankaruus.md
+++ b/Loitsut/Sankaruus.md
@@ -1,3 +1,8 @@
+---
+title: "Sankaruus"
+description: "Sankaruus on 1-piirin lumoamisloitsu, joka tekee kosketetusta olennosta immuunin kauhistumiselle ja antaa väliaikaisia osumapisteitä joka vuoro."
+---
+
 ### Sankaruus
 
 *1-piirin lumoaminen*

--- a/Loitsut/Sateenkaaripurske.md
+++ b/Loitsut/Sateenkaaripurske.md
@@ -1,3 +1,8 @@
+---
+title: "Sateenkaaripurske"
+description: "Sateenkaaripurske on 7-piirin luomisloitsu, joka ampuu kahdeksan erivärisiä säteitä 24 metrin kartioon, joista kukin aiheuttaa oman vahinkonsa."
+---
+
 ### Sateenkaaripurske
 
 *7-piirin luominen*

--- a/Loitsut/Sateenkaarivalli.md
+++ b/Loitsut/Sateenkaarivalli.md
@@ -1,3 +1,8 @@
+---
+title: "Sateenkaarivalli"
+description: "Sateenkaarivalli on 9-piirin suojelusloitsu, joka luo hohtavan, monikerroksisen valliesteen enintään 24 metrin pituudelta kymmeneksi minuutiksi."
+---
+
 ### Sateenkaarivalli
 
 *9-piirin suojelus*

--- a/Loitsut/Selvännäkeminen.md
+++ b/Loitsut/Selvännäkeminen.md
@@ -1,3 +1,8 @@
+---
+title: "Selvännäkeminen"
+description: "Selvännäkeminen on 3-piirin ennustamisloitsu, joka luo näkymättömän anturin tutun tai ilmeisen sijainnin taakse, jonka kautta voi kuulla tai nähdä."
+---
+
 ### Selvännäkeminen
 
 *3-piirin ennustaminen* 

--- a/Loitsut/Sieluastia.md
+++ b/Loitsut/Sieluastia.md
@@ -1,3 +1,8 @@
+---
+title: "Sieluastia"
+description: "Sieluastia on 6-piirin kuolontaikuusloitsu, joka lähettää loitsijan sielun ainesastiasta käsin havainnoimaan ympäristöä tai haltuunottamaan humanoidin."
+---
+
 ### Sieluastia
 
 *6-piirin kuolontaikuus*

--- a/Loitsut/Siunaus.md
+++ b/Loitsut/Siunaus.md
@@ -1,3 +1,8 @@
+---
+title: "Siunaus"
+description: "Siunaus on 1-piirin lumoamisloitsu, joka antaa enintään kolmelle kohteelle mahdollisuuden lisätä 1n4 pelastus- ja hyökkäysheittoihinsa."
+---
+
 ### Siunaus
 
 *1-piirin lumoaminen*

--- a/Loitsut/Sivuaskel.md
+++ b/Loitsut/Sivuaskel.md
@@ -1,3 +1,8 @@
+---
+title: "Sivuaskel"
+description: "Sivuaskel on 2-piirin kutsumisloitsu, joka siirtää loitsijan bonustoimintona välittömästi enintään 12 metrin päähän näköpiirissä olevaan tyhjään tilaan."
+---
+
 ### Sivuaskel
 
 *2-piirin kutsuminen*

--- a/Loitsut/Sokaiseva_säde.md
+++ b/Loitsut/Sokaiseva_säde.md
@@ -1,3 +1,8 @@
+---
+title: "Sokaiseva säde"
+description: "Sokaiseva säde on 6-piirin luomisloitsu, joka lähettää 24 metriä pitkän valolinjan aiheuttaen 6n8 hohkavahinkoa ja sokaisee epäonnistuneen kohteen."
+---
+
 ### Sokaiseva säde
 
 *6-piirin luominen*

--- a/Loitsut/Sokeus_kuurous.md
+++ b/Loitsut/Sokeus_kuurous.md
@@ -1,3 +1,8 @@
+---
+title: "Sokeus / kuurous"
+description: "Sokeus / kuurous on 2-piirin kuolontaikuusloitsu, joka tekee kohteesta sokeutuneen tai kuuroutuneen epäonnistuneen sitkeys-pelastusheiton jälkeen."
+---
+
 ### Sokeus / kuurous
 
 *2-piirin kuolontaikuus*

--- a/Loitsut/Sumennus.md
+++ b/Loitsut/Sumennus.md
@@ -1,3 +1,8 @@
+---
+title: "Sumennus"
+description: "Sumennus on 2-piirin illuusioloitsu, joka sumentaa loitsijan ääriviivat niin, että kaikilla häneen kohdistuvilla hyökkäysheitoilla on haitta."
+---
+
 ### Sumennus
 
 *2-piirin illuusio*

--- a/Loitsut/Sumupilvi.md
+++ b/Loitsut/Sumupilvi.md
@@ -1,3 +1,8 @@
+---
+title: "Sumupilvi"
+description: "Sumupilvi on 1-piirin kutsumisloitsu, joka luo kahdeksan metrin säteisen sumupilven valittuun kohtaan tunnin ajaksi, ellei kova tuuli sitä hajota."
+---
+
 ### Sumupilvi
 
 *1-piirin kutsuminen*

--- a/Loitsut/Suoja_energialta.md
+++ b/Loitsut/Suoja_energialta.md
@@ -1,3 +1,8 @@
+---
+title: "Suoja energialta"
+description: "Suoja energialta on 3-piirin suojelusloitsu, joka antaa vapaaehtoiselle olennolle sietokyvyn valittua vahinkotyyppiä, kuten tulta, vastaan tunniksi."
+---
+
 ### Suoja energialta
 
 *3-piirin suojelus* 

--- a/Loitsut/Suojaus_eläviltä.md
+++ b/Loitsut/Suojaus_eläviltä.md
@@ -1,3 +1,8 @@
+---
+title: "Suojaus eläviltä"
+description: "Suojaus eläviltä on 5-piirin suojelusloitsu, joka luo neljän metrin säteisen esteen, joka sulkee ulos kaikki paitsi epäkuolleet ja rakennelmat."
+---
+
 ### Suojaus eläviltä
 
 *5-piirin suojelus*

--- a/Loitsut/Suojaus_hyvältä_ja_pahalta.md
+++ b/Loitsut/Suojaus_hyvältä_ja_pahalta.md
@@ -1,3 +1,8 @@
+---
+title: "Suojaus hyvältä ja pahalta"
+description: "Suojaus hyvältä ja pahalta on 1-piirin suojelusloitsu, joka suojaa kosketettua olentoa elementaaleilta, epäkuolleilta, keijuilta ja piruilta."
+---
+
 ### Suojaus hyvältä ja pahalta
 
 *1-piirin suojelus*

--- a/Loitsut/Suojaus_myrkyltä.md
+++ b/Loitsut/Suojaus_myrkyltä.md
@@ -1,3 +1,8 @@
+---
+title: "Suojaus myrkyltä"
+description: "Suojaus myrkyltä on 2-piirin suojelusloitsu, joka neutraloi yhden myrkyn kosketetusta olennosta ja antaa sietokyvyn myrkkyvahinkoa vastaan tunniksi."
+---
+
 ### Suojaus myrkyltä
 
 *2-piirin suojelus*

--- a/Loitsut/Suojelushenget.md
+++ b/Loitsut/Suojelushenget.md
@@ -1,3 +1,8 @@
+---
+title: "Suojelushenget"
+description: "Suojelushenget on 3-piirin kutsumisloitsu, joka kutsuu henkiä puolittamaan vihollisten nopeuden ja koettelemaan heitä viisaus-pelastusheitolla."
+---
+
 ### Suojelushenget
 
 *3-piirin kutsuminen* 

--- a/Loitsut/Surman_mahtisana.md
+++ b/Loitsut/Surman_mahtisana.md
@@ -1,3 +1,8 @@
+---
+title: "Surman mahtisana"
+description: "Surman mahtisana on 9-piirin lumoamisloitsu, joka surmaa välittömästi kohteen olennon, jolla on enintään 100 osumapistettä jäljellä."
+---
+
 ### Surman mahtisana
 
 *9-piirin lumoaminen*

--- a/Loitsut/Suurennus_kutistus.md
+++ b/Loitsut/Suurennus_kutistus.md
@@ -1,3 +1,8 @@
+---
+title: "Suurennus / kutistus"
+description: "Suurennus / kutistus on 2-piirin muovaamisloitsu, joka kasvattaa tai kutistaa olennon tai esineen kokoa merkittävästi loitsun keston ajaksi."
+---
+
 ### Suurennus / kutistus
 
 *2-piirin muovaaminen*

--- a/Loitsut/Sähköshokki.md
+++ b/Loitsut/Sähköshokki.md
@@ -1,3 +1,8 @@
+---
+title: "Sähköshokki"
+description: "Sähköshokki on luomisen taikakonsti, joka tekee lähitaisteluhyökkäyksen ja aiheuttaa 1n8 salamavahinkoa sekä estää kohteen reaktiot hetkeksi."
+---
+
 ### Sähköshokki
 
 *Taikakonsti, luominen*

--- a/Loitsut/Säänhallinta.md
+++ b/Loitsut/Säänhallinta.md
@@ -1,3 +1,8 @@
+---
+title: "Säänhallinta"
+description: "Säänhallinta on 8-piirin muovaamisloitsu, joka antaa loitsijalle vallan muuttaa sademäärää, lämpötilaa ja tuulta kahdeksan kilometrin säteellä."
+---
+
 ### Säänhallinta
 
 *8-piirin muovaaminen*

--- a/Loitsut/Tahdon_hallinta.md
+++ b/Loitsut/Tahdon_hallinta.md
@@ -1,3 +1,8 @@
+---
+title: "Tahdon hallinta"
+description: "Tahdon hallinta on 5-piirin lumoamisloitsu, jolla lumoat humanoidin ja saat siihen telepaattisen käskyvallan pelastusheiton epäonnistuessa."
+---
+
 ### Tahdon hallinta
 
 *5-piirin lumoaminen*

--- a/Loitsut/Taika-ase.md
+++ b/Loitsut/Taika-ase.md
@@ -1,3 +1,8 @@
+---
+title: "Taika-ase"
+description: "Taika-ase on 2-piirin muovaamisloitsu, joka koskettamalla muuttaa aseen maagiseksi antaen +1 bonuksen hyökkäys- ja vahinkoheittoihin."
+---
+
 ### Taika-ase
 
 *2-piirin muovaaminen*

--- a/Loitsut/Taikahäkki.md
+++ b/Loitsut/Taikahäkki.md
@@ -1,3 +1,8 @@
+---
+title: "Taikahäkki"
+description: "Taikahäkki on 7-piirin luomisloitsu, joka luo näkymättömän häkin tai umpinaisen laatikon vangiksi valitsemallesi alueelle."
+---
+
 ### Taikahäkki
 
 *7-piirin luominen*

--- a/Loitsut/Taikakehä.md
+++ b/Loitsut/Taikakehä.md
@@ -1,3 +1,8 @@
+---
+title: "Taikakehä"
+description: "Taikakehä on 3-piirin suojelusloitsu, joka luo sylinterimäisen alueen estäen valitun olentotyypin, kuten epäkuolleiden tai pirujen, pääsyn sisään."
+---
+
 ### Taikakehä
 
 *3-piirin suojelus* 

--- a/Loitsut/Taikakupla.md
+++ b/Loitsut/Taikakupla.md
@@ -1,3 +1,8 @@
+---
+title: "Taikakupla"
+description: "Taikakupla on 4-piirin luomisloitsu, joka sulkee olennon tai esineen läpäisemättömään, painottomaan kuplaan loitsun keston ajaksi."
+---
+
 ### Taikakupla
 
 *4-piirin luominen*

--- a/Loitsut/Taikakäsi.md
+++ b/Loitsut/Taikakäsi.md
@@ -1,3 +1,8 @@
+---
+title: "Taikakäsi"
+description: "Taikakäsi on 5-piirin luomisloitsu, joka kutsuu suuren hohtavan käden tekemään komentojasi ja hyökkäämään kättesi liikkeitä matkien."
+---
+
 ### Taikakäsi
 
 *5-piirin luominen*

--- a/Loitsut/Taikakätkö.md
+++ b/Loitsut/Taikakätkö.md
@@ -1,3 +1,8 @@
+---
+title: "Taikakätkö"
+description: "Taikakätkö on 6-piirin kutsumisloitsu, joka piilottaa esineen turvaan safiirin avulla ja tuo sen käteesi murskaamalla safiirin."
+---
+
 ### Taikakätkö
 
 *6-piirin kutsuminen*

--- a/Loitsut/Taikaovi.md
+++ b/Loitsut/Taikaovi.md
@@ -1,3 +1,8 @@
+---
+title: "Taikaovi"
+description: "Taikaovi on 5-piirin muovaamisloitsu, joka luo väliaikaisen kulkuaukon seinään, lattiaan tai kattoon korkeintaan 12 metrin syvyydelle."
+---
+
 ### Taikaovi
 
 *5-piirin muovaaminen*

--- a/Loitsut/Taikaratsu.md
+++ b/Loitsut/Taikaratsu.md
@@ -1,3 +1,8 @@
+---
+title: "Taikaratsu"
+description: "Taikaratsu on 3-piirin illuusioloitsu, joka kutsuu satuloidun haamuratsun kuljettamaan valitsemaasi olentoa tunnin ajan."
+---
+
 ### Taikaratsu
 
 *3-piirin illuusio (rituaali)* 

--- a/Loitsut/Taikasuoja.md
+++ b/Loitsut/Taikasuoja.md
@@ -1,3 +1,8 @@
+---
+title: "Taikasuoja"
+description: "Taikasuoja on 6-piirin suojelusloitsu, joka luo esteen torjumaan viidennen tai matalamman piirin loitsujen vaikutukset ympäriltäsi."
+---
+
 ### Taikasuoja
 
 *6-piirin suojelus*

--- a/Loitsut/Taikatemppu.md
+++ b/Loitsut/Taikatemppu.md
@@ -1,3 +1,8 @@
+---
+title: "Taikatemppu"
+description: "Taikatemppu on aloittelijoiden käyttämä muovaamisen taikakonsti, jolla luo pieniä aistivaikutuksia, puhdistaa esineitä tai sytyttää liekkejä."
+---
+
 ### Taikatemppu
 
 *Taikakonsti, muovaaminen*

--- a/Loitsut/Taikuuden_purkaminen.md
+++ b/Loitsut/Taikuuden_purkaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Taikuuden purkaminen"
+description: "Taikuuden purkaminen on 3-piirin suojelusloitsu, joka päättää kohteena olevan maagisen vaikutuksen tai loitsun välittömästi."
+---
+
 ### Taikuuden purkaminen
 
 *3-piirin suojelus* 

--- a/Loitsut/Tainnutuksen_mahtisana.md
+++ b/Loitsut/Tainnutuksen_mahtisana.md
@@ -1,3 +1,8 @@
+---
+title: "Tainnutuksen mahtisana"
+description: "Tainnutuksen mahtisana on 8-piirin lumoamisloitsu, joka voi taannuttaa kohteen välittömästi, jos sillä on 150 osumapistettä tai vähemmän."
+---
+
 ### Tainnutuksen mahtisana
 
 *8-piirin lumoaminen*

--- a/Loitsut/Taivaallisen_olennon_kutsuminen.md
+++ b/Loitsut/Taivaallisen_olennon_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Taivaallisen olennon kutsuminen"
+description: "Taivaallisen olennon kutsuminen on 7-piirin kutsumisloitsu, joka tuo avuksesi ystävällisen taivaallisen olennon haastearvoon 4 asti."
+---
+
 ### Taivaallisen olennon kutsuminen
 
 *7-piirin kutsuminen*

--- a/Loitsut/Tanssivat_valot.md
+++ b/Loitsut/Tanssivat_valot.md
@@ -1,3 +1,8 @@
+---
+title: "Tanssivat valot"
+description: "Tanssivat valot on luomisen taikakonsti, joka luo neljä liikuteltavaa valopalloa, jotka voi yhdistää myös humanoidin muotoiseksi hahmoksi."
+---
+
 ### Tanssivat valot
 
 *Taikakonsti, luominen*

--- a/Loitsut/Tarkka_isku.md
+++ b/Loitsut/Tarkka_isku.md
@@ -1,3 +1,8 @@
+---
+title: "Tarkka isku"
+description: "Tarkka isku on ennustamisen taikakonsti, joka antaa edun seuraavaan hyökkäysheittoosi osoittamaasi kohdetta vastaan."
+---
+
 ### Tarkka isku
 
 *Taikakonsti, ennustaminen*

--- a/Loitsut/Tarttuva_tauti.md
+++ b/Loitsut/Tarttuva_tauti.md
@@ -1,3 +1,8 @@
+---
+title: "Tarttuva tauti"
+description: "Tarttuva tauti on 5-piirin kuolontaikuusloitsu, joka lähitaisteluhyökkäyksellä tartuttaa kohteeseen valitsemasi vakavan taudin."
+---
+
 ### Tarttuva tauti
 
 *5-piirin kuolontaikuus*

--- a/Loitsut/Tehtävä.md
+++ b/Loitsut/Tehtävä.md
@@ -1,3 +1,8 @@
+---
+title: "Tehtävä"
+description: "Tehtävä on 5-piirin lumoamisloitsu, joka pakottaa olennon noudattamaan antamaasi käskyä 30 päivän ajan uhalla kärsiä hengenvahinkoa."
+---
+
 ### Tehtävä
 
 *5-piirin lumoaminen*

--- a/Loitsut/Telekinesia.md
+++ b/Loitsut/Telekinesia.md
@@ -1,3 +1,8 @@
+---
+title: "Telekinesia"
+description: "Telekinesia on 5-piirin muovaamisloitsu, joka antaa kyvyn liikuttaa ja manipuloida olentoja tai esineitä ajatuksen voimalla kantaman sisällä."
+---
+
 ### Telekinesia
 
 *5-piirin muovaaminen*

--- a/Loitsut/Telepaattinen_side.md
+++ b/Loitsut/Telepaattinen_side.md
@@ -1,3 +1,8 @@
+---
+title: "Telepaattinen side"
+description: "Telepaattinen side on 5-piirin ennustamisen rituaaliloitsu, joka luo telepaattisen yhteyden korkeintaan kahdeksan halukkaan olennon välille."
+---
+
 ### Telepaattinen side
 
 *5-piirin ennustaminen (rituaali)*

--- a/Loitsut/Teleportaatiokehä.md
+++ b/Loitsut/Teleportaatiokehä.md
@@ -1,3 +1,8 @@
+---
+title: "Teleportaatiokehä"
+description: "Teleportaatiokehä on 5-piirin kutsumisloitsu, joka piirtää maahan sinetin ja avaa portaalin toiseen tunnettuun teleportaatiokehään."
+---
+
 ### Teleportaatiokehä
 
 *5-piirin kutsuminen*

--- a/Loitsut/Teleportti.md
+++ b/Loitsut/Teleportti.md
@@ -1,3 +1,8 @@
+---
+title: "Teleportti"
+description: "Teleportti on 7-piirin kutsumisloitsu, joka siirtää sinut ja mukanaolijat välittömästi tuttuun paikkaan tai kohteeseen."
+---
+
 ### Teleportti
 
 *7-piirin kutsuminen*

--- a/Loitsut/Teleporttisuoja.md
+++ b/Loitsut/Teleporttisuoja.md
@@ -1,3 +1,8 @@
+---
+title: "Teleporttisuoja"
+description: "Teleporttisuoja on 6-piirin suojelusloitsu, joka estää teleportaation ja portaalimatkustamisen suuren alueen sisälle vuorokauden ajan."
+---
+
 ### Teleporttisuoja
 
 *6-piirin suojelus*

--- a/Loitsut/Toivomus.md
+++ b/Loitsut/Toivomus.md
@@ -1,3 +1,8 @@
+---
+title: "Toivomus"
+description: "Toivomus on 9-piirin kutsumisloitsu ja voimakkain kuolevaisen taikuus, jolla voi kopioida minkä loitsun tahansa tai muokata todellisuutta."
+---
+
 ### Toivomus
 
 *9-piirin kutsuminen*

--- a/Loitsut/Toivon_majakka.md
+++ b/Loitsut/Toivon_majakka.md
@@ -1,3 +1,8 @@
+---
+title: "Toivon majakka"
+description: "Toivon majakka on 3-piirin suojelusloitsu, joka antaa valitsemillesi olennoille edun viisaus- ja kuolemanpelastusheittoihin sekä täyden parannuksen."
+---
+
 ### Toivon majakka
 
 *3-piirin suojelus* 

--- a/Loitsut/Torjuva_merkki.md
+++ b/Loitsut/Torjuva_merkki.md
@@ -1,3 +1,8 @@
+---
+title: "Torjuva merkki"
+description: "Torjuva merkki on 3-piirin suojelusloitsu, joka piilottaa pintaan tai esineeseen laukeavan merkin, kunnes se puretaan tai laukaistaan."
+---
+
 ### Torjuva merkki
 
 *3-piirin suojelus* 

--- a/Loitsut/Tosi_näkymättömyys.md
+++ b/Loitsut/Tosi_näkymättömyys.md
@@ -1,3 +1,8 @@
+---
+title: "Tosi näkymättömyys"
+description: "Tosi näkymättömyys on 4-piirin illuusioloitsu, joka tekee sinusta tai kosketetusta olennosta näkymättömän vaikka hyökkäisit tai loitsisit."
+---
+
 ### Tosi näkymättömyys
 
 *4-piirin illuusio*

--- a/Loitsut/Tosinäkeminen.md
+++ b/Loitsut/Tosinäkeminen.md
@@ -1,3 +1,8 @@
+---
+title: "Tosinäkeminen"
+description: "Tosinäkeminen on 6-piirin ennustamisloitsu, joka antaa kosketetulle olennolle kyvyn nähdä salaovet ja katsoa eetteriin 48 metrin päähän."
+---
+
 ### Tosinäkeminen
 
 *6-piirin ennustaminen*

--- a/Loitsut/Tuhosäde.md
+++ b/Loitsut/Tuhosäde.md
@@ -1,3 +1,8 @@
+---
+title: "Tuhosäde"
+description: "Tuhosäde on 6-piirin muovaamisloitsu, jonka vihreä säde aiheuttaa 10n6+40 energiavahinkoa ja voi tuhota kohteen kokonaan tomuksi."
+---
+
 ### Tuhosäde
 
 *6-piirin muovaaminen*

--- a/Loitsut/Tulikilpi.md
+++ b/Loitsut/Tulikilpi.md
@@ -1,3 +1,8 @@
+---
+title: "Tulikilpi"
+description: "Tulikilpi on 4-piirin luomisloitsu, joka peittää vartalosi liekeillä antaen suojan kylmää tai kuumuutta vastaan ja vahingoittaen lähelle tulevia."
+---
+
 ### Tulikilpi
 
 *4-piirin luominen*

--- a/Loitsut/Tulimyrsky.md
+++ b/Loitsut/Tulimyrsky.md
@@ -1,3 +1,8 @@
+---
+title: "Tulimyrsky"
+description: "Tulimyrsky on 7-piirin luomisloitsu, joka sytyttää valitulle alueelle raivoavan liekkimyrskyn ja aiheuttaa 7n10 tulivahinkoa."
+---
+
 ### Tulimyrsky
 
 *7-piirin luominen*

--- a/Loitsut/Tulinuoli.md
+++ b/Loitsut/Tulinuoli.md
@@ -1,3 +1,8 @@
+---
+title: "Tulinuoli"
+description: "Tulinuoli on luomisen taikakonsti, joka heittää tulenlieskan kohteeseen aiheuttaen 1n10 tulivahinkoa ja sytyttäen tulenarat esineet."
+---
+
 ### Tulinuoli
 
 *Taikakonsti, luominen*

--- a/Loitsut/Tulipallo.md
+++ b/Loitsut/Tulipallo.md
@@ -1,3 +1,8 @@
+---
+title: "Tulipallo"
+description: "Tulipallo on 3-piirin luomisloitsu, joka räjäyttää liekkipallon kantamalla ja aiheuttaa 8n6 tulivahinkoa ketteryys-pelastusheitolla puolitettuna."
+---
+
 ### Tulipallo
 
 *3-piirin luominen* 

--- a/Loitsut/Tulivalli.md
+++ b/Loitsut/Tulivalli.md
@@ -1,3 +1,8 @@
+---
+title: "Tulivalli"
+description: "Tulivalli on 4-piirin luomisloitsu, joka luo läpinäkymättömän tulisen vallin ja aiheuttaa 5n8 tulivahinkoa sen vaikutusalueella oleville."
+---
+
 ### Tulivalli
 
 *4-piirin luominen*

--- a/Loitsut/Tunnistaminen.md
+++ b/Loitsut/Tunnistaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Tunnistaminen"
+description: "Tunnistaminen on 1-piirin ennustamisen rituaaliloitsu, joka selvittää taikaesineen ominaisuudet ja käytön koskettamalla sitä."
+---
+
 ### Tunnistaminen
 
 *1-piirin ennustaminen (rituaali)*

--- a/Loitsut/Turvasatama.md
+++ b/Loitsut/Turvasatama.md
@@ -1,3 +1,8 @@
+---
+title: "Turvasatama"
+description: "Turvasatama on 4-piirin suojelusloitsu, joka suojaa valitun alueen äänen, näön ja loitsujen tunkeutumiselta 24 tunnin ajan."
+---
+
 ### Turvasatama
 
 *4-piirin suojelus*

--- a/Loitsut/Tuulenvire.md
+++ b/Loitsut/Tuulenvire.md
@@ -1,3 +1,8 @@
+---
+title: "Tuulenvire"
+description: "Tuulenvire on 2-piirin luomisloitsu, joka puhaltaa voimakasta tuulta työntäen olentoja ja sammuttaen avotulet valitulla alueella."
+---
+
 ### Tuulenvire
 
 *2-piirin luominen*

--- a/Loitsut/Tuulikävely.md
+++ b/Loitsut/Tuulikävely.md
@@ -1,3 +1,8 @@
+---
+title: "Tuulikävely"
+description: "Tuulikävely on 6-piirin muovaamisloitsu, joka muuttaa sinut ja kymmenen vapaaehtoista pilvimuotoon 120 metrin lentonopeudella kahdeksaksi tunniksi."
+---
+
 ### Tuulikävely
 
 *6-piirin muovaaminen*

--- a/Loitsut/Tyhjämieli.md
+++ b/Loitsut/Tyhjämieli.md
@@ -1,3 +1,8 @@
+---
+title: "Tyhjämieli"
+description: "Tyhjämieli on 8-piirin suojelusloitsu, joka tekee kosketetusta olennosta immuunin hengenvahingolle, lumoukselle ja mielenluvulle vuorokauden ajan."
+---
+
 ### Tyhjämieli
 
 *8-piirin suojelus*

--- a/Loitsut/Ukkosen_kutsuminen.md
+++ b/Loitsut/Ukkosen_kutsuminen.md
@@ -1,3 +1,8 @@
+---
+title: "Ukkosen kutsuminen"
+description: "Ukkosen kutsuminen on 3-piirin kutsumisloitsu, joka manaa myrskypilven yläpuolellesi ja aiheuttaa 3n10 salamavahinkoa valitulle alueelle."
+---
+
 ### Ukkosen kutsuminen
 
 *3-piirin kutsuminen* 

--- a/Loitsut/Ulottuvuusovi.md
+++ b/Loitsut/Ulottuvuusovi.md
@@ -1,3 +1,8 @@
+---
+title: "Ulottuvuusovi"
+description: "Ulottuvuusovi on 4-piirin kutsumisloitsu, joka teleporttaa sinut välittömästi mihin tahansa pisteeseen 200 metrin kantaman sisällä."
+---
+
 ### Ulottuvuusovi
 
 *4-piirin kutsuminen*

--- a/Loitsut/Ulottuvuussiirtymä.md
+++ b/Loitsut/Ulottuvuussiirtymä.md
@@ -1,3 +1,8 @@
+---
+title: "Ulottuvuussiirtymä"
+description: "Ulottuvuussiirtymä on 7-piirin kutsumisloitsu, joka siirtää sinut ja seurueesi äänirautaa käyttäen toiselle maailmatasolle."
+---
+
 ### Ulottuvuussiirtymä
 
 *7-piirin kutsuminen*

--- a/Loitsut/Uni.md
+++ b/Loitsut/Uni.md
@@ -1,3 +1,8 @@
+---
+title: "Uni"
+description: "Uni on 1-piirin lumoamisloitsu, joka vaivuttaa olentoja uneen 5n8 osumapisteen verran valitulta alueelta vähiten osumapisteitä omaavista alkaen."
+---
+
 ### Uni
 
 *1-piirin lumoaminen*

--- a/Loitsut/Univiesti.md
+++ b/Loitsut/Univiesti.md
@@ -1,3 +1,8 @@
+---
+title: "Univiesti"
+description: "Univiesti on 5-piirin illuusioloitsu, joka lähettää viestinviejän tuntemasi olennon uneen välittämään haluamasi sanoman."
+---
+
 ### Univiesti
 
 *5-piirin illuusio*

--- a/Loitsut/Uskon_kilpi.md
+++ b/Loitsut/Uskon_kilpi.md
@@ -1,3 +1,8 @@
+---
+title: "Uskon kilpi"
+description: "Uskon kilpi on 1-piirin suojelusloitsu, joka ympäröi valitun olennon hohtavalla kajolla antaen +2 bonuksen puolustukseen."
+---
+
 ### Uskon kilpi
 
 *1-piirin suojelus*

--- a/Loitsut/Uskon_miekka.md
+++ b/Loitsut/Uskon_miekka.md
@@ -1,3 +1,8 @@
+---
+title: "Uskon miekka"
+description: "Uskon miekka on 2-piirin luomisloitsu, joka luo leijuvan terän tekemään lähitaisteluhyökkäyksiä 1n8 energiavahingolla bonustoimintona."
+---
+
 ### Uskon miekka
 
 *2-piirin luominen*

--- a/Loitsut/Uskon_suojelija.md
+++ b/Loitsut/Uskon_suojelija.md
@@ -1,3 +1,8 @@
+---
+title: "Uskon suojelija"
+description: "Uskon suojelija on 4-piirin kutsumisloitsu, joka luo aavemaisen vartijan vahingoittamaan lähelle tulevia vihamielisiä olentoja hohkavahingolla."
+---
+
 ### Uskon suojelija
 
 *4-piirin kutsuminen*

--- a/Loitsut/Uudelleensyntyminen.md
+++ b/Loitsut/Uudelleensyntyminen.md
@@ -1,3 +1,8 @@
+---
+title: "Uudelleensyntyminen"
+description: "Uudelleensyntyminen on 5-piirin muovaamisloitsu, joka herättää kuolleen humanoidin uudessa kehossa, jonka lajin pelinjohtaja arpoo taulukosta."
+---
+
 ### Uudelleensyntyminen
 
 *5-piirin muovaaminen*

--- a/Loitsut/Vahingoittaminen.md
+++ b/Loitsut/Vahingoittaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Vahingoittaminen"
+description: "Vahingoittaminen on 6-piirin kuolontaikuusloitsu, joka aiheuttaa kohteelle 14n6 kuolonvahinkoa ja laskee tilapäisesti osumapistemaksimia."
+---
+
 ### Vahingoittaminen
 
 *6-piirin kuolontaikuus*

--- a/Loitsut/Vahtikoira.md
+++ b/Loitsut/Vahtikoira.md
@@ -1,3 +1,8 @@
+---
+title: "Vahtikoira"
+description: "Vahtikoira on 4-piirin kutsumisloitsu, joka luo näkymättömän haamuvahtikoiran haukkumaan salasanattomien lähestyjien saapuessa lähelle."
+---
+
 ### Vahtikoira
 
 *4-piirin kutsuminen*

--- a/Loitsut/Vainajan_siunaus.md
+++ b/Loitsut/Vainajan_siunaus.md
@@ -1,3 +1,8 @@
+---
+title: "Vainajan siunaus"
+description: "Vainajan siunaus on 2-piirin kuolontaikuusloitsu, joka estää koskettua ruumista maatumasta tai muuttumasta epäkuolleeksi kymmenen päivän ajan."
+---
+
 ### Vainajan siunaus
 
 *2-piirin kuolontaikuus*

--- a/Loitsut/Vakauttaminen.md
+++ b/Loitsut/Vakauttaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Vakauttaminen"
+description: "Vakauttaminen on kuolontaikuuden taikakonsti, joka koskettamalla vakauttaa kuolevan olennon, jolla on 0 osumapistettä."
+---
+
 ### Vakauttaminen
 
 *Taikakonsti, kuolontaikuus*

--- a/Loitsut/Valeasu.md
+++ b/Loitsut/Valeasu.md
@@ -1,3 +1,8 @@
+---
+title: "Valeasu"
+description: "Valeasu on 1-piirin illuusioloitsu, joka muuttaa ulkonäköäsi ja varusteitasi tunnin ajaksi näyttäen sinut toiselta henkilöltä."
+---
+
 ### Valeasu
 
 *1-piirin illuusio*

--- a/Loitsut/Valemuoto.md
+++ b/Loitsut/Valemuoto.md
@@ -1,3 +1,8 @@
+---
+title: "Valemuoto"
+description: "Valemuoto on 5-piirin illuusioloitsu, joka muokkaa haluamiesi olentojen ulkonäköä kahdeksaksi tunniksi karismapelastusheiton salliessa vastustaa."
+---
+
 ### Valemuoto
 
 *5-piirin illuusio*

--- a/Loitsut/Valheeton_alue.md
+++ b/Loitsut/Valheeton_alue.md
@@ -1,3 +1,8 @@
+---
+title: "Valheeton alue"
+description: "Valheeton alue on 2-piirin lumoamisloitsu, joka luo alueen, jossa olennot eivät voi tarkoituksella valehdella kymmenen minuutin ajan."
+---
+
 ### Valheeton alue
 
 *2-piirin lumoaminen*

--- a/Loitsut/Valmistaminen.md
+++ b/Loitsut/Valmistaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Valmistaminen"
+description: "Valmistaminen on 4-piirin muovaamisloitsu, joka muuttaa raaka-aineet valmiiksi esineiksi, kuten silloiksi, köysiksi tai vaatteiksi."
+---
+
 ### Valmistaminen
 
 *4-piirin muovaaminen*

--- a/Loitsut/Valo.md
+++ b/Loitsut/Valo.md
@@ -1,3 +1,8 @@
+---
+title: "Valo"
+description: "Valo on luomisen taikakonsti, joka saa koskettamansa esineen loistamaan kirkasta valoa tunnin ajaksi valitsemassasi värissä."
+---
+
 ### Valo
 
 *Taikakonsti, luominen*

--- a/Loitsut/Valojuova.md
+++ b/Loitsut/Valojuova.md
@@ -1,3 +1,8 @@
+---
+title: "Valojuova"
+description: "Valojuova on 1-piirin luomisloitsu, joka aiheuttaa kantamahyökkäyksellä 4n6 hohkavahinkoa ja antaa edun seuraavaan kohteeseen tehtävään hyökkäykseen."
+---
+
 ### Valojuova
 
 *1-piirin luominen*

--- a/Loitsut/Vampyyrikosketus.md
+++ b/Loitsut/Vampyyrikosketus.md
@@ -1,3 +1,8 @@
+---
+title: "Vampyyrikosketus"
+description: "Vampyyrikosketus on 3-piirin kuolontaikuusloitsu, joka lähitaisteluhyökkäyksellä aiheuttaa 3n6 kuolonvahinkoa ja parantaa sinua puolella siitä."
+---
+
 ### Vampyyrikosketus
 
 *3-piirin kuolontaikuus* 

--- a/Loitsut/Vapaa_liikkuvuus.md
+++ b/Loitsut/Vapaa_liikkuvuus.md
@@ -1,3 +1,8 @@
+---
+title: "Vapaa liikkuvuus"
+description: "Vapaa liikkuvuus on 4-piirin suojelusloitsu, joka estää vaikean maaston, sitomisen ja halvaannuttamisen vaikutukset kosketetulla olennolla tunnin ajan."
+---
+
 ### Vapaa liikkuvuus
 
 *4-piirin suojelus*

--- a/Loitsut/Varjelus.md
+++ b/Loitsut/Varjelus.md
@@ -1,3 +1,8 @@
+---
+title: "Varjelus"
+description: "Varjelus on 1-piirin suojelusloitsu, joka pakottaa hyökkääjät onnistumaan viisauspelastusheitossa ennen suojatun olennon vahingoittamista."
+---
+
 ### Varjelus
 
 *1-piirin suojelus*

--- a/Loitsut/Varjomaailma.md
+++ b/Loitsut/Varjomaailma.md
@@ -1,3 +1,8 @@
+---
+title: "Varjomaailma"
+description: "Varjomaailma on 8-piirin kutsumisloitsu, joka avaa varjo-oven omaan luomaasi tai aiemmin luotuun tyhjään huoneeseen tunnin ajaksi."
+---
+
 ### Varjomaailma
 
 *8-piirin kutsuminen*

--- a/Loitsut/Vastaloitsu.md
+++ b/Loitsut/Vastaloitsu.md
@@ -1,3 +1,8 @@
+---
+title: "Vastaloitsu"
+description: "Vastaloitsu on 3-piirin suojelusloitsu, joka reaktiona keskeyttää toisen olennon loitsimisen ja mitätöi sen vaikutuksen."
+---
+
 ### Vastaloitsu
 
 *3-piirin suojelus* 

--- a/Loitsut/Vastustamaton_rytmi.md
+++ b/Loitsut/Vastustamaton_rytmi.md
@@ -1,3 +1,8 @@
+---
+title: "Vastustamaton rytmi"
+description: "Vastustamaton rytmi on 6-piirin lumoamisloitsu, joka pakottaa kohteen tanssimaan koomisesti ja antaa haitan sen ketteryyspelastusheittoihin."
+---
+
 ### Vastustamaton rytmi
 
 *6-piirin lumoaminen*

--- a/Loitsut/Vastustus.md
+++ b/Loitsut/Vastustus.md
@@ -1,3 +1,8 @@
+---
+title: "Vastustus"
+description: "Vastustus on suojelun taikakonsti, joka antaa kosketetulle olennolle mahdollisuuden lisätä 1n4 valitsemaansa pelastusheittoon."
+---
+
 ### Vastustus
 
 *Taikakonsti, suojelus*

--- a/Loitsut/Veden_hallinta.md
+++ b/Loitsut/Veden_hallinta.md
@@ -1,3 +1,8 @@
+---
+title: "Veden hallinta"
+description: "Veden hallinta on 4-piirin muovaamisloitsu, joka nostaa, laskee, ohjaa tai muuttaa suuren vesialueen virtausta 40 metrin kuution sisällä."
+---
+
 ### Veden hallinta
 
 *4-piirin muovaaminen*

--- a/Loitsut/Veden_hengittäminen.md
+++ b/Loitsut/Veden_hengittäminen.md
@@ -1,3 +1,8 @@
+---
+title: "Veden hengittäminen"
+description: "Veden hengittäminen on 3-piirin muovaamisloitsu, joka antaa korkeintaan kymmenelle olennolle kyvyn hengittää veden alla vuorokauden ajan."
+---
+
 ### Veden hengittäminen
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Veden_ja_ruoan_luominen.md
+++ b/Loitsut/Veden_ja_ruoan_luominen.md
@@ -1,3 +1,8 @@
+---
+title: "Veden ja ruoan luominen"
+description: "Veden ja ruoan luominen on 3-piirin kutsumisloitsu, joka luo 20 kiloa ruokaa ja 120 litraa vettä riittämään viidelletoista henkilölle vuorokaudeksi."
+---
+
 ### Veden ja ruoan luominen
 
 *3-piirin kutsuminen* 

--- a/Loitsut/Veden_luominen_tai_tuhoaminen.md
+++ b/Loitsut/Veden_luominen_tai_tuhoaminen.md
@@ -1,3 +1,8 @@
+---
+title: "Veden luominen tai tuhoaminen"
+description: "Veden luominen tai tuhoaminen on 1-piirin muovaamisloitsu, joka luo tai tuhoaa korkeintaan 40 litraa vettä tai sumua kantaman sisällä."
+---
+
 ### Veden luominen tai tuhoaminen
 
 *1-piirin muovaaminen*

--- a/Loitsut/Velhon_lukko.md
+++ b/Loitsut/Velhon_lukko.md
@@ -1,3 +1,8 @@
+---
+title: "Velhon lukko"
+description: "Velhon lukko on 2-piirin suojelusloitsu, joka lukitsee koskettamasi oven, arkun tai portin maagisesti, kunnes se puretaan tai murretaan."
+---
+
 ### Velhon lukko
 
 *2-piirin suojelus*

--- a/Loitsut/Velhon_suu.md
+++ b/Loitsut/Velhon_suu.md
@@ -1,3 +1,8 @@
+---
+title: "Velhon suu"
+description: "Velhon suu on 2-piirin illuusion rituaaliloitsu, joka piilottaa esineeseen enintään 25 sanan viestin, jonka se lausuu ehdon täyttyessä."
+---
+
 ### Velhon suu
 
 *2-piirin illuusio (rituaali)*

--- a/Loitsut/Velhonkäsi.md
+++ b/Loitsut/Velhonkäsi.md
@@ -1,3 +1,8 @@
+---
+title: "Velhonkäsi"
+description: "Velhonkäsi on kutsumisen taikakonsti, joka luo leijuvan aavemaisen käden avaamaan lukitsemattomia ovia ja siirtämään korkeintaan viiden kilon esineitä."
+---
+
 ### Velhonkäsi
 
 *Taikakonsti, kutsuminen*

--- a/Loitsut/Velhonlieska.md
+++ b/Loitsut/Velhonlieska.md
@@ -1,3 +1,8 @@
+---
+title: "Velhonlieska"
+description: "Velhonlieska on luomisen taikakonsti, joka ampuu rätisevän energiasäteen aiheuttaen 1n10 energiavahinkoa ja luo useampia säteitä korkeammilla tasoilla."
+---
+
 ### Velhonlieska
 
 *Taikakonsti, luominen*

--- a/Loitsut/Velhonnäytös.md
+++ b/Loitsut/Velhonnäytös.md
@@ -1,3 +1,8 @@
+---
+title: "Velhonnäytös"
+description: "Velhonnäytös on muovaamisen taikakonsti, joka luo pieniä yliluonnollisia ihmeitä kuten jyrisevän äänen, väräjäviä liekkejä tai paukahtelevia ovia."
+---
+
 ### Velhonnäytös
 *Taikakonsti, muovaaminen*
 **Loitsimisviive:** 1 toiminto

--- a/Loitsut/Velhonsilmä.md
+++ b/Loitsut/Velhonsilmä.md
@@ -1,3 +1,8 @@
+---
+title: "Velhonsilmä"
+description: "Velhonsilmä on 4-piirin ennustamisloitsu, joka luo näkymättömän liikuteltavan silmän välittämään näkemänsä mieleesi tunnin ajan."
+---
+
 ### Velhonsilmä
 
 *4-piirin ennustaminen*

--- a/Loitsut/Velhovankila.md
+++ b/Loitsut/Velhovankila.md
@@ -1,3 +1,8 @@
+---
+title: "Velhovankila"
+description: "Velhovankila on 9-piirin suojelusloitsu, joka vangitsee olennon pysyvästi viisauspelastusheiton epäonnistuessa, kunnes loitsu purkautuu."
+---
+
 ### Velhovankila
 
 *9-piirin suojelus*

--- a/Loitsut/Verkko.md
+++ b/Loitsut/Verkko.md
@@ -1,3 +1,8 @@
+---
+title: "Verkko"
+description: "Verkko on 2-piirin kutsumisloitsu, joka täyttää 4x4 metrin alueen tahmealla hämähäkinseitillä hidastaen ja sitoen siihen jääneet olennot."
+---
+
 ### Verkko
 
 *2-piirin kutsuminen*

--- a/Loitsut/Vetten_päällä_kävely.md
+++ b/Loitsut/Vetten_päällä_kävely.md
@@ -1,3 +1,8 @@
+---
+title: "Vetten päällä kävely"
+description: "Vetten päällä kävely on 3-piirin muovaamisloitsu, joka antaa korkeintaan kymmenelle olennolle kyvyn kulkea veden tai muun nesteen pinnalla tunnin ajan."
+---
+
 ### Vetten päällä kävely
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Viesti.md
+++ b/Loitsut/Viesti.md
@@ -1,3 +1,8 @@
+---
+title: "Viesti"
+description: "Viesti on muovaamisen taikakonsti, joka välittää kuiskatun sanoman kohteelle kantaman sisällä myös seinien ja esteiden läpi."
+---
+
 ### Viesti
 
 *Taikakonsti, muovaaminen*

--- a/Loitsut/Viivästetty_tulipallo.md
+++ b/Loitsut/Viivästetty_tulipallo.md
@@ -1,3 +1,8 @@
+---
+title: "Viivästetty tulipallo"
+description: "Viivästetty tulipallo on 7-piirin luomisloitsu, joka räjähtää helmen muodossa aiheuttaen 12n6 tulivahinkoa, jonka määrä kasvaa viivytyksen aikana."
+---
+
 ### Viivästetty tulipallo
 
 *7-piirin luominen*

--- a/Loitsut/Vilahdus.md
+++ b/Loitsut/Vilahdus.md
@@ -1,3 +1,8 @@
+---
+title: "Vilahdus"
+description: "Vilahdus on 3-piirin muovaamisloitsu, joka heittää joka vuorolla n20 lähettäen sinut satunnaisesti hetkeksi eetteriin ja takaisin."
+---
+
 ### Vilahdus
 
 *3-piirin muovaaminen* 

--- a/Loitsut/Villipetojen_hallinta.md
+++ b/Loitsut/Villipetojen_hallinta.md
@@ -1,3 +1,8 @@
+---
+title: "Villipetojen hallinta"
+description: "Villipetojen hallinta on 4-piirin lumoamisloitsu, joka kesyttää näkemäsi eläimen antaen sinulle telepaattisen käskyvallan pelastusheiton epäonnistuessa."
+---
+
 ### Villipetojen hallinta
 
 *4-piirin lumoaminen*

--- a/Loitsut/Voimakenttä.md
+++ b/Loitsut/Voimakenttä.md
@@ -1,3 +1,8 @@
+---
+title: "Voimakenttä"
+description: "Voimakenttä on 5-piirin luomisloitsu, joka luo näkymättömän läpäisemättömän seinän tai puolipallon 4 metrin säteelle kymmenen minuutin ajaksi."
+---
+
 ### Voimakenttä
 
 *5-piirin luominen*

--- a/Loitsut/Voimallinen_palautus.md
+++ b/Loitsut/Voimallinen_palautus.md
@@ -1,3 +1,8 @@
+---
+title: "Voimallinen palautus"
+description: "Voimallinen palautus on 5-piirin suojelusloitsu, joka poistaa kosketetulta olennolta lumouksen, kivettymisen, kirouksen tai ominaisuuden heikennyksen."
+---
+
 ### Voimallinen palautus
 
 *5-piirin suojelus*

--- a/Loitsut/Voimallinen_parannus.md
+++ b/Loitsut/Voimallinen_parannus.md
@@ -1,3 +1,8 @@
+---
+title: "Voimallinen parannus"
+description: "Voimallinen parannus on 9-piirin luomisloitsu, joka parantaa yhteensä 700 osumapistettä jaettuna näkemiesi haavoittuneiden olentojen kesken."
+---
+
 ### Voimallinen parannus
 
 *9-piirin luominen*

--- a/Loitsut/Voimapalautus.md
+++ b/Loitsut/Voimapalautus.md
@@ -1,3 +1,8 @@
+---
+title: "Voimapalautus"
+description: "Voimapalautus on 2-piirin suojelusloitsu, joka koskettamalla poistaa kohteelta halvaantumisen, kuuroutumisen, myrkytyksen tai sokeuden."
+---
+
 ### Voimapalautus
 
 *2-piirin suojelus*

--- a/Loitsut/Vähäinen_illuusio.md
+++ b/Loitsut/Vähäinen_illuusio.md
@@ -1,3 +1,8 @@
+---
+title: "Vähäinen illuusio"
+description: "Vähäinen illuusio on illuusion taikakonsti, joka luo äänen tai kuvan esineestä minuutin ajaksi kantaman sisälle."
+---
+
 ### Vähäinen illuusio
 
 *Taikakonsti, illuusio*

--- a/Loitsut/Vähäisempi_henkiinherätys.md
+++ b/Loitsut/Vähäisempi_henkiinherätys.md
@@ -1,3 +1,8 @@
+---
+title: "Vähäisempi henkiinherätys"
+description: "Vähäisempi henkiinherätys on 7-piirin kuolontaikuusloitsu, joka palauttaa henkiin enintään 100 vuotta kuolleena olleen olennon ja parantaa sairaudet."
+---
+
 ### Vähäisempi henkiinherätys
 
 *7-piirin kuolontaikuus*

--- a/Loitsut/Vähämielisyys.md
+++ b/Loitsut/Vähämielisyys.md
@@ -1,3 +1,8 @@
+---
+title: "Vähämielisyys"
+description: "Vähämielisyys on 8-piirin lumoamisloitsu, joka aiheuttaa mielen pirstovan hyökkäyksen laskien älykkyyden ja karisman pelastusheiton epäonnistuessa."
+---
+
 ### Vähämielisyys
 
 *8-piirin lumoaminen*

--- a/Loitsut/Väripurske.md
+++ b/Loitsut/Väripurske.md
@@ -1,3 +1,8 @@
+---
+title: "Väripurske"
+description: "Väripurske on 1-piirin illuusioloitsu, joka sokaisee kartion sisällä olevia olentoja 6n10 osumapisteen verran yhden kierroksen ajaksi."
+---
+
 ### Väripurske
 
 *1-piirin illuusio*

--- a/Loitsut/Ylimaallinen_liittolainen.md
+++ b/Loitsut/Ylimaallinen_liittolainen.md
@@ -1,3 +1,8 @@
+---
+title: "Ylimaallinen liittolainen"
+description: "Ylimaallinen liittolainen on 6-piirin kutsumisloitsu, joka pyytää tuntemaltasi ylimaalliselta voimalta avuksi elementaalin, pirun tai taivaallisen olennon."
+---
+
 ### Ylimaallinen liittolainen
 
 *6-piirin kutsuminen*

--- a/Loitsut/Ylimaallinen_yhteys.md
+++ b/Loitsut/Ylimaallinen_yhteys.md
@@ -1,3 +1,8 @@
+---
+title: "Ylimaallinen yhteys"
+description: "Ylimaallinen yhteys on 5-piirin ennustamisen rituaaliloitsu, joka luo yhteyden toisella maailmatasolla asuvaan tietoisuuteen mielenterveyden hinnalla."
+---
+
 ### Ylimaallinen yhteys
 
 *5-piirin ennustaminen (rituaali)*

--- a/Olotilat/Olotilat.md
+++ b/Olotilat/Olotilat.md
@@ -1,3 +1,8 @@
+---
+title: "Olotilat"
+description: "Olotilat-sivu käy läpi pelimekaniikan olotilat, kuten sokaistu, halvaantunut ja näkymätön, sekä niiden vaikutukset ja kestot taisteluissa."
+---
+
 # Olotilat
 Olotilat vaikuttavat olentojen kykyihin, ominaisuuksiin ja pelimekaniikkaan useilla eri tavoilla ja voivat olla seurausta loitsuista, hahmoluokkien ominaisuuksista tai hirviöiden hyökkäyksistä. Useimmat olotilat ovat haitallisia esimerkiksi silloin kun olento on vaikkapa *sokaistu*, mutta jotkin olotilat ovat eduksi kuten olennon ollessa *näkymätön*.
 Olotila kestää kunnes se on joko kumottu, esimerkiksi olennon ollessa *maissa* hän kumoaa sen nousemalla pystyyn tai kunnes jokin tietty aika on kulunut. Vaikutuksessa joko on aiheuttanut tietyn olotilan on yleensä määritelty myös olotilan kesto.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+title: "Legendoja & Lohikäärmeitä SRD"
+description: "README kertoo Legendoja & Lohikäärmeitä SRD:n taustasta, Creative Commons -lisenssistä ja siitä, miten materiaali pohjautuu 5. laitoksen SRD 5.1:een."
+---
+
 # Legendoja & Lohikäärmeitä SRD
 
 ## Tietoa

--- a/Sanasto.md
+++ b/Sanasto.md
@@ -1,3 +1,8 @@
+---
+title: "Sanasto 5.0"
+description: "Sanasto 5.0 kokoaa Legendoja & Lohikäärmeitä -roolipelin suomennossanaston, joka poikkeaa paikoin suorasta käännöksestä sopiakseen paremmin peliin."
+---
+
 # Sanasto 5.0
 Legendoja & lohikäärmeitä on suomenkielinen fantasiaroolipeli. Sen pohjana on Wizards of The coastin julkaisema 5. laitoksen sääntöjen englanninkielinen SRD-aineisto. Tätä sanastoa on käytetty SRD- ja muuta OGL-aineistoa kääntäessä ja kirjoittaessa.
 Kyseessä ei ole suora käännössanasto vaan esimerkiksi joissain tapauksissa olemme korvanneet sisältöä paremmin Legendoihin & lohikäärmeisiin istuvaksi, esimerkiksi dulcimerin kanteleella.

--- a/Sisällysluettelo.md
+++ b/Sisällysluettelo.md
@@ -1,3 +1,8 @@
+---
+title: "Sisällys"
+description: "Sisällysluettelo listaa Legendoja & Lohikäärmeitä SRD:n rakenteen hahmonluonnista varusteisiin, olotiloihin, loitsuihin ja sanastoon."
+---
+
 # Sisällys
 
 Hahmonluonti

--- a/Varusteet/Aseet.md
+++ b/Varusteet/Aseet.md
@@ -1,3 +1,8 @@
+---
+title: "Aseet"
+description: "Aseet-sivu esittää asetaulukon hintoineen, painoineen ja vahinkoineen sekä jaottelee lähitaistelu- ja kantama-aseet yksinkertaisiin ja sota-aseisiin."
+---
+
 # Aseet
 
 Näet asetaulukosta yleisimmät fantasiamaailmoissa käytetyt

--- a/Varusteet/Haarniskat_ja_kilvet.md
+++ b/Varusteet/Haarniskat_ja_kilvet.md
@@ -1,3 +1,8 @@
+---
+title: "Haarniskat ja kilvet"
+description: "Haarniskat ja kilvet -sivu listaa haarniskatyypit hintoineen ja puolustusarvoineen sekä selittää haarniskakoulutuksen puutteen haitat."
+---
+
 # Haarniskat ja kilvet
 
 Näet haarniskataulukosta yleisimmät fantasiamaailmoissa käytetyt haarniskat sekä niiden 

--- a/Varusteet/Kauppatavara.md
+++ b/Varusteet/Kauppatavara.md
@@ -1,3 +1,8 @@
+---
+title: "Kauppatavara"
+description: "Kauppatavara-sivu näyttää yleisimpien kauppatavaroiden, kuten viljan ja kankaiden, arvot fantasiamaailman talousjärjestelmässä."
+---
+
 # Kauppatavara
 Suurinta osaa vauraudesta ei lasketa kolikkoina vaan karjana,
 viljana, maaomaisuutena, oikeutena kerätä veroja tai oikeuksina

--- a/Varusteet/Kulut.md
+++ b/Varusteet/Kulut.md
@@ -1,3 +1,8 @@
+---
+title: "Kulut"
+description: "Kulut-sivu selittää elintasokulut, jotka kattavat majoituksen, ruoan ja varusteiden ylläpidon hahmon seikkailujen välissä."
+---
+
 # Kulut
 
 Silloin kun seikkailijat eivät laskeudu maanalaisiin kätkettyihin

--- a/Varusteet/Palvelut.md
+++ b/Varusteet/Palvelut.md
@@ -1,3 +1,8 @@
+---
+title: "Palvelut"
+description: "Palvelut-sivu esittelee palkollisten, kuten puuseppien ja seppien, tarjoamat palvelut ja niiden hinnat seikkailijoiden käyttöön."
+---
+
 # Palvelut
 
 Seikkailijat voivat maksaa sivuhahmoille siitä, että he auttavat

--- a/Varusteet/Pikkutavara.md
+++ b/Varusteet/Pikkutavara.md
@@ -1,3 +1,8 @@
+---
+title: "Pikkutavara"
+description: "Pikkutavara-sivu tarjoaa 1n100-taulukon pienistä ja arvoituksellisista esineistä, joita hahmo voi arpoa luonnin yhteydessä."
+---
+
 # Pikkutavara
 
 Tehtyäsi hahmon voit heittää kerran seuraavasta taulukosta ja saat kyseisen esineen. Pikkutavara on jotain pientä, ehkä hieman

--- a/Varusteet/Ratsut_ja_kulkuneuvot.md
+++ b/Varusteet/Ratsut_ja_kulkuneuvot.md
@@ -1,3 +1,8 @@
+---
+title: "Ratsut ja kulkuvälineet"
+description: "Ratsut ja kulkuvälineet -sivu listaa eläinten ja ajoneuvojen nopeudet ja kantokyvyt matkustamiseen sivistyksen ulkopuolella."
+---
+
 # Ratsut ja kulkuvälineet
 
 Hyvän ratsun avulla liikut nopeasti paikasta toiseen kaupunkien ja sivistyksen ulkopuolella. Ratsu pystyy kantamaan puolestasi huomattavan määrän varusteita, jotka muuten hidastaisivat tai tekisivät matkanteon jalan jopa mahdottomaksi. Ratsut ja muut eläimet -taulukossa on listattu näiden eläinten nopeus ja kantokyky.

--- a/Varusteet/Ruoka_ja_juoma.md
+++ b/Varusteet/Ruoka_ja_juoma.md
@@ -1,3 +1,8 @@
+---
+title: "Ruoka, juoma ja majoitus"
+description: "Ruoka, juoma ja majoitus -sivu esittää hinnat oluesta juhla-aterioihin sekä majoitustasot ankeasta aristokraattiseen."
+---
+
 # Ruoka, juoma ja majoitus
 
 Seuraavissa taulukoissa on annettu hinnat yksittäisille elintarvikkeille

--- a/Varusteet/Seikkailuvarusteet.md
+++ b/Varusteet/Seikkailuvarusteet.md
@@ -1,3 +1,8 @@
+---
+title: "Seikkailuvarusteet"
+description: "Seikkailuvarusteet-sivu selittää erikoissäännöt tavaroille, kuten ainespussille ja alkemistin tulelle, joka syttyy tuleen ilman kanssa."
+---
+
 # Seikkailuvarusteet
 
 Tämä osio kertoo, mille tavaroille on olemassa erikoissääntöjä.

--- a/Varusteet/Tyokalut.md
+++ b/Varusteet/Tyokalut.md
@@ -1,3 +1,8 @@
+---
+title: "Työkalut"
+description: "Työkalut-sivu käy läpi työkalupätevyyden merkityksen ja listaa käsityöläisen työkalut, joilla voi lisätä pätevyysbonuksen ominaisuusheittoihin."
+---
+
 # Työkalut
 
 Työkalu on väline, jonka avulla jonkin asian luominen, rakentaminen tai korjaaminen on mahdollista. Voit saada pätevyyden jonkin työkalun käyttöön hahmoluokasta, taustasta tai lajista.

--- a/Varusteet/Valmispakkaukset.md
+++ b/Varusteet/Valmispakkaukset.md
@@ -1,3 +1,8 @@
+---
+title: "Valmispakkaukset"
+description: "Valmispakkaukset-sivu listaa valmiit aloitusvarustepaketit, kuten diplomaatin ja luolantutkijan varusteet, edullisempaan pakettihintaan."
+---
+
 # Valmispakkaukset
 Valmispakkaukset ovat valmiita kokoelmia seikkailijan aloitusvarusteita. 
 Näiden valmiiden kokonaisuuksien sisältö on

--- a/Varusteet/Varusteet.md
+++ b/Varusteet/Varusteet.md
@@ -1,3 +1,8 @@
+---
+title: "Varusteet"
+description: "Varusteet-sivu esittelee fantasiamaailman kauppatorien tarjonnan kääpiöiden miekoista haltioiden jousiin ja maahisten jalokiviin."
+---
+
 # Varusteet
 Suurkaupunkien kauppakortteleissa kaukaisten maiden
 karavaanien ja kauppalaivojen sisältö kohtaavat. Niissä on


### PR DESCRIPTION
## Tausta

SRD-dokumenteissa ei ole frontmatteria, joten julkaisualustat eivät voi lukea sivukohtaista otsikkoa tai kuvausta.

Myrrys.com-sivustolla tämä tarkoitti, että **kaikki 348 SRD-sivua käyttivät samaa otsikkoa** (`L&L - SRD`) ja samaa kuvausta. Hakukoneille sivut näyttivät siltä kuin sama sivu olisi monistettu 348 kertaa, jolloin ne käytännössä jäävät pois hakutuloksista.

## Muutos

Jokaiseen `.md`-tiedostoon lisätään frontmatter:

```yaml
---
title: "Tulipallo"
description: "Tulipallo on 3-piirin luomisloitsu, joka räjäyttää liekkipallon kantamalla ja aiheuttaa 8n6 tulivahinkoa ketteryys-pelastusheitolla puolitettuna."
---
```

- **title** — dokumentin ensimmäisestä otsikosta
- **description** — dokumentin sisällöstä kirjoitettu tiivistelmä

Kaikki 348 otsikkoa ja kuvausta on tarkistettu: ne ovat keskenään uniikkeja, 90–155 merkkiä pitkiä eivätkä sisällä Markdown-merkintää.

## Yhteensopivuus

Muutos on **puhtaasti additiivinen**. Dokumenttien sisältö ei muutu millään tavalla — diffissä on pelkkiä lisäyksiä, ei poistoja. Frontmatter on vakiintunut Markdown-käytäntö, eikä se vaikuta lähteen lukemiseen.

## Huomio

`Loitsut/Kaasumuoto.md` saa titleksi `Kaasumuoto`, vaikka tiedoston otsikkona lukee virheellisesti `Druidintaito`. Itse otsikko korjataan seuraavassa PR:ssä (`fix/srd-links-and-headings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)